### PR TITLE
Tighter dependencies with features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,10 +44,22 @@ jobs:
           sudo apt-get update
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
         if: runner.os == 'linux'
-      - name: Build & run tests
-        run: cargo test
+      - name: Build & run tests (slim)
+        run: cargo test --no-default-features
         env:
           CARGO_INCREMENTAL: 0
+      - name: Build & run tests (ui)
+        run: cargo test --no-default-features --features="bevy_ui"
+        env:
+          CARGO_INCREMENTAL: 1
+      - name: Build & run tests (sprite)
+        run: cargo test --no-default-features --features="bevy_sprite"
+        env:
+          CARGO_INCREMENTAL: 1
+      - name: Build & run tests (all)
+        run: cargo test --all-features
+        env:
+          CARGO_INCREMENTAL: 1
 
   coverage:
     name: Coverage
@@ -87,7 +99,7 @@ jobs:
           RUST_BACKTRACE=1 cargo install --version 0.19.1 cargo-tarpaulin
       - name: Generate code coverage
         run: |
-          RUST_BACKTRACE=1 cargo tarpaulin --verbose --timeout 120 --out Lcov --workspace
+          RUST_BACKTRACE=1 cargo tarpaulin --all-features --verbose --timeout 120 --out Lcov --workspace
           ls -la
       - name: Upload code coverage
         uses: coverallsapp/github-action@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Better dependencies: Introduced features `bevy_sprite` and `bevy_ui` taking a dependency on the same-named crates of Bevy, and removed the forced dependency on `bevy/render`. The new features are enabled by default, for discoverability, and only impact the prebuilt lenses. The library now builds without any Bevy optional feature.
+
 ## [0.3.3] - 2022-03-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,16 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 exclude = ["examples/*.gif", ".github", "release.md"]
 
+[features]
+default = ["bevy_sprite", "bevy_ui"]
+# Enable built-in lenses for Bevy sprites
+bevy_sprite = ["bevy/bevy_sprite", "bevy/bevy_render"]
+# Enable built-in lenses for Bevy UI
+bevy_ui = ["bevy/bevy_ui", "bevy/bevy_text", "bevy/bevy_render"]
+
 [dependencies]
 interpolation = "0.2"
-bevy = { version = "0.6", default-features = false, features = [ "render" ] }
+bevy = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 bevy-inspector-egui = "0.8"
@@ -25,11 +32,11 @@ required-features = [ "bevy/bevy_winit" ]
 
 [[example]]
 name = "colormaterial_color"
-required-features = [ "bevy/bevy_winit" ]
+required-features = [ "bevy_sprite", "bevy/bevy_winit" ]
 
 [[example]]
 name = "sprite_color"
-required-features = [ "bevy/bevy_winit" ]
+required-features = [ "bevy_sprite", "bevy/bevy_winit" ]
 
 [[example]]
 name = "transform_translation"
@@ -41,11 +48,11 @@ required-features = [ "bevy/bevy_winit" ]
 
 [[example]]
 name = "ui_position"
-required-features = [ "bevy/bevy_winit" ]
+required-features = [ "bevy_ui", "bevy/bevy_winit" ]
 
 [[example]]
 name = "text_color"
-required-features = [ "bevy/bevy_winit" ]
+required-features = [ "bevy_ui", "bevy/bevy_winit" ]
 
 [[example]]
 name = "sequence"

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -76,6 +76,7 @@ pub trait Lens<T> {
 ///
 /// [`color`]: https://docs.rs/bevy/0.6.1/bevy/text/struct.TextStyle.html#structfield.color
 /// [`Text`]: https://docs.rs/bevy/0.6.1/bevy/text/struct.Text.html
+#[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TextColorLens {
     /// Start color.
@@ -86,6 +87,7 @@ pub struct TextColorLens {
     pub section: usize,
 }
 
+#[cfg(feature = "bevy_ui")]
 impl Lens<Text> for TextColorLens {
     fn lerp(&mut self, target: &mut Text, ratio: f32) {
         // Note: Add<f32> for Color affects alpha, but not Mul<f32>. So use Vec4 for consistency.
@@ -277,6 +279,7 @@ impl Lens<Transform> for TransformScaleLens {
 ///
 /// [`position`]: https://docs.rs/bevy/0.6.1/bevy/ui/struct.Style.html#structfield.position
 /// [`Style`]: https://docs.rs/bevy/0.6.1/bevy/ui/struct.Style.html
+#[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiPositionLens {
     /// Start position.
@@ -285,6 +288,7 @@ pub struct UiPositionLens {
     pub end: Rect<Val>,
 }
 
+#[cfg(feature = "bevy_ui")]
 fn lerp_val(start: &Val, end: &Val, ratio: f32) -> Val {
     match (start, end) {
         (Val::Percent(start), Val::Percent(end)) => Val::Percent(start + (end - start) * ratio),
@@ -293,6 +297,7 @@ fn lerp_val(start: &Val, end: &Val, ratio: f32) -> Val {
     }
 }
 
+#[cfg(feature = "bevy_ui")]
 impl Lens<Style> for UiPositionLens {
     fn lerp(&mut self, target: &mut Style, ratio: f32) {
         target.position = Rect {
@@ -308,6 +313,7 @@ impl Lens<Style> for UiPositionLens {
 ///
 /// [`color`]: https://docs.rs/bevy/0.6.1/bevy/sprite/struct.ColorMaterial.html#structfield.color
 /// [`ColorMaterial`]: https://docs.rs/bevy/0.6.1/bevy/sprite/struct.ColorMaterial.html
+#[cfg(feature = "bevy_sprite")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ColorMaterialColorLens {
     /// Start color.
@@ -316,6 +322,7 @@ pub struct ColorMaterialColorLens {
     pub end: Color,
 }
 
+#[cfg(feature = "bevy_sprite")]
 impl Lens<ColorMaterial> for ColorMaterialColorLens {
     fn lerp(&mut self, target: &mut ColorMaterial, ratio: f32) {
         // Note: Add<f32> for Color affects alpha, but not Mul<f32>. So use Vec4 for consistency.
@@ -330,6 +337,7 @@ impl Lens<ColorMaterial> for ColorMaterialColorLens {
 ///
 /// [`color`]: https://docs.rs/bevy/0.6.1/bevy/sprite/struct.Sprite.html#structfield.color
 /// [`Sprite`]: https://docs.rs/bevy/0.6.1/bevy/sprite/struct.Sprite.html
+#[cfg(feature = "bevy_sprite")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct SpriteColorLens {
     /// Start color.
@@ -338,6 +346,7 @@ pub struct SpriteColorLens {
     pub end: Color,
 }
 
+#[cfg(feature = "bevy_sprite")]
 impl Lens<Sprite> for SpriteColorLens {
     fn lerp(&mut self, target: &mut Sprite, ratio: f32) {
         // Note: Add<f32> for Color affects alpha, but not Mul<f32>. So use Vec4 for consistency.
@@ -353,6 +362,7 @@ mod tests {
     use super::*;
     use std::f32::consts::TAU;
 
+    #[cfg(feature = "bevy_ui")]
     #[test]
     fn text_color() {
         let mut lens = TextColorLens {
@@ -582,6 +592,7 @@ mod tests {
         assert!(transform.scale.abs_diff_eq(Vec3::new(0.3, 0.6, -1.2), 1e-5));
     }
 
+    #[cfg(feature = "bevy_sprite")]
     #[test]
     fn colormaterial_color() {
         let mut lens = ColorMaterialColorLens {
@@ -603,6 +614,7 @@ mod tests {
         assert_eq!(mat.color, Color::rgba(0.7, 0., 0.3, 1.0));
     }
 
+    #[cfg(feature = "bevy_sprite")]
     #[test]
     fn sprite_color() {
         let mut lens = SpriteColorLens {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -34,10 +34,14 @@ pub struct TweeningPlugin;
 impl Plugin for TweeningPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<TweenCompleted>()
-            .add_system(component_animator_system::<Transform>)
-            .add_system(component_animator_system::<Text>)
-            .add_system(component_animator_system::<Style>)
-            .add_system(component_animator_system::<Sprite>)
+            .add_system(component_animator_system::<Transform>);
+
+        #[cfg(eature = "bevy_ui")]
+        app.add_system(component_animator_system::<Text>)
+            .add_system(component_animator_system::<Style>);
+
+        #[cfg(eature = "bevy_sprite")]
+        app.add_system(component_animator_system::<Sprite>)
             .add_system(asset_animator_system::<ColorMaterial>);
     }
 }


### PR DESCRIPTION
Enable minimal dependencies with new features `bevu_sprite` and
`bevy_ui`, removing the `bevy/render` mandatory dependency. Those new
features are enabled by default, and enable the built-in lenses for the
related Bevy crates. The core `bevy_tweening` crate itself does not take
any optional Bevy dependency anymore, allowing for a slim build with
only the core Bevy functionalities.