### PR TITLE
Fix `lib.rs` doc to not rely on feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,15 +57,8 @@
 //! );
 //!
 //! commands
-//!     // Spawn a Sprite entity to animate the position of.
-//!     .spawn_bundle(SpriteBundle {
-//!         sprite: Sprite {
-//!             color: Color::RED,
-//!             custom_size: Some(Vec2::new(size, size)),
-//!             ..Default::default()
-//!         },
-//!         ..Default::default()
-//!     })
+//!     // Spawn an entity to animate the position of.
+//!     .spawn_bundle(TransformBundle::default())
 //!     // Add an Animator component to control and execute the animation.
 //!     .insert(Animator::new(tween));
 //! # }


### PR DESCRIPTION
Change the example in the `lib.rs` module documentation to not rely on
the `bevy_sprite` feature, to allow building cleanly with the
`--no-default-features` flag. Replace the use of `SpriteBundle` with
`TransformBundle`, which is not behind a feature flag so is alway
available.