### PR TITLE
Upgrade `bevy-inspector-egui` and fix examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ interpolation = "0.2"
 bevy = { version = "0.7", default-features = false }
 
 [dev-dependencies]
-bevy-inspector-egui = "0.8"
+bevy-inspector-egui = "0.10"
 
 [[example]]
 name = "menu"

--- a/examples/colormaterial_color.rs
+++ b/examples/colormaterial_color.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "ColorMaterialColorLens".to_string(),
             width: 1200.,
             height: 600.,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "Menu".to_string(),
             width: 800.,
             height: 400.,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "Sequence".to_string(),
             width: 600.,
             height: 600.,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/sprite_color.rs
+++ b/examples/sprite_color.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "SpriteColorLens".to_string(),
             width: 1200.,
             height: 600.,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/text_color.rs
+++ b/examples/text_color.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "TextColorLens".to_string(),
             width: WIDTH,
             height: HEIGHT,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/transform_rotation.rs
+++ b/examples/transform_rotation.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "TransformRotationLens".to_string(),
             width: 1400.,
             height: 600.,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/transform_translation.rs
+++ b/examples/transform_translation.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "TransformPositionLens".to_string(),
             width: 1400.,
             height: 600.,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/ui_position.rs
+++ b/examples/ui_position.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             title: "UiPositionLens".to_string(),
             width: 1400.,
             height: 600.,
-            vsync: true,
+            present_mode: bevy::window::PresentMode::Fifo, // vsync
             ..Default::default()
         })
         .add_plugins(DefaultPlugins)


### PR DESCRIPTION
Upgrade the version of `bevy-inspector-egui` to `0.10` for Bevy v0.7
compatibility, otherwise the examples were building with Bevy v0.6. Fix
the examples which now build correctly with Bevy v0.7.