### PR TITLE
Support running an animation N times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `is_forward()` and `is_backward()` convenience helpers to `TweeningDirection`.
-- Add `Tween::set_direction()` and `Tween::with_direction()` which allow configuring the playback direction of a tween, allowing to play it backward from end to start.
-- Support dynamically changing an animation's speed with `Animator::set_speed`
-- Add `AnimationSystem` label to tweening tick systems
-- A `BoxedTweenable` type to make working with `Box<dyn Tweenable + ...>` easier
+- Added `is_forward()` and `is_backward()` convenience helpers to `TweeningDirection`.
+- Added `Tween::set_direction()` and `Tween::with_direction()` which allow configuring the playback direction of a tween, allowing to play it backward from end to start.
+- Added support for dynamically changing an animation's speed with `Animator::set_speed`.
+- Added `AnimationSystem` label to tweening tick systems.
+- Added `BoxedTweenable` type to make working with `Box<dyn Tweenable + ...>` easier.
+- Added `RepeatCount` and `RepeatStrategy` for more granular control over animation looping.
+- Added `with_repeat_count()` and `with_repeat_strategy()` builder methods to `Tween<T>`.
 
 ### Changed
 
-- Double boxing in `Sequence` and `Tracks` was fixed. As a result, any custom tweenables
+- Double boxing in `Sequence` and `Tracks` was fixed. As a result, any custom tweenables.
   should implement `From` for `BoxedTweenable` to make those APIs easier to use.
+- Removed the `tweening_type` parameter from the signature of `Tween<T>::new()`; use `with_repeat_count()` and `with_repeat_strategy()` instead.
+
+### Removed
+
+- Removed `Tweenable::is_looping()`, which was not implemented for most tweenables.
+- Removed `TweeningType` in favor of `RepeatCount` and `RepeatStrategy`.
 
 ## [0.4.0] - 2022-04-16
 

--- a/examples/colormaterial_color.rs
+++ b/examples/colormaterial_color.rs
@@ -79,13 +79,14 @@ fn setup(
 
         let tween = Tween::new(
             *ease_function,
-            TweeningType::PingPong,
             Duration::from_secs(1),
             ColorMaterialColorLens {
                 start: Color::RED,
                 end: Color::BLUE,
             },
-        );
+        )
+        .with_repeat_count(RepeatCount::Infinite)
+        .with_repeat_strategy(RepeatStrategy::Bounce);
 
         commands
             .spawn_bundle(MaterialMesh2dBundle {

--- a/examples/colormaterial_color.rs
+++ b/examples/colormaterial_color.rs
@@ -84,7 +84,7 @@ fn setup(
             },
         )
         .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::Bounce);
+        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
 
         commands
             .spawn_bundle(MaterialMesh2dBundle {

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -52,7 +52,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         start_time_ms += 500;
         let tween_scale = Tween::new(
             EaseFunction::BounceOut,
-            TweeningType::Once,
             Duration::from_secs(2),
             TransformScaleLens {
                 start: Vec3::splat(0.01),

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -1,6 +1,8 @@
-use bevy::prelude::*;
-use bevy_tweening::{lens::*, *};
 use std::time::Duration;
+
+use bevy::prelude::*;
+
+use bevy_tweening::{lens::*, *};
 
 fn main() {
     App::default()
@@ -107,15 +109,16 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Vec3::new(margin, screen_y - margin, 0.),
         Vec3::new(margin, margin, 0.),
     ];
-    // Build a sequence from an iterator over a Tweenable (here, a Tween<Transform>)
+    // Build a sequence from an iterator over a Tweenable (here, a
+    // Tracks<Transform>)
     let seq = Sequence::new(dests.windows(2).enumerate().map(|(index, pair)| {
         Tracks::new([
             Tween::new(
                 EaseFunction::QuadraticInOut,
                 Duration::from_millis(250),
-                TransformRotationLens {
-                    start: Quat::IDENTITY,
-                    end: Quat::from_rotation_z(180_f32.to_radians()),
+                TransformRotateZLens {
+                    start: 0.,
+                    end: 180_f32.to_radians(),
                 },
             )
             .with_repeat_count(RepeatCount::Finite(4))

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -119,7 +119,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 },
             )
             .with_repeat_count(RepeatCount::Finite(4))
-            .with_repeat_strategy(RepeatStrategy::Bounce),
+            .with_repeat_strategy(RepeatStrategy::MirroredRepeat),
             Tween::new(
                 EaseFunction::QuadraticInOut,
                 Duration::from_secs(1),

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -111,16 +111,27 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ];
     // Build a sequence from an iterator over a Tweenable (here, a Tween<Transform>)
     let seq = Sequence::new(dests.windows(2).enumerate().map(|(index, pair)| {
-        Tween::new(
-            EaseFunction::QuadraticInOut,
-            TweeningType::Once,
-            Duration::from_secs(1),
-            TransformPositionLens {
-                start: pair[0] - center,
-                end: pair[1] - center,
-            },
-        )
-        .with_completed_event(true, index as u64) // Get an event after each segment
+        Tracks::new([
+            Tween::new(
+                EaseFunction::QuadraticInOut,
+                Duration::from_millis(250),
+                TransformRotationLens {
+                    start: Quat::IDENTITY,
+                    end: Quat::from_rotation_z(180_f32.to_radians()),
+                },
+            )
+            .with_repeat_count(RepeatCount::Finite(4))
+            .with_repeat_strategy(RepeatStrategy::Bounce),
+            Tween::new(
+                EaseFunction::QuadraticInOut,
+                Duration::from_secs(1),
+                TransformPositionLens {
+                    start: pair[0] - center,
+                    end: pair[1] - center,
+                },
+            )
+            .with_completed_event(true, index as u64), // Get an event after each segment
+        ])
     }));
 
     commands
@@ -139,7 +150,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // size at the same time.
     let tween_move = Tween::new(
         EaseFunction::QuadraticInOut,
-        TweeningType::Once,
         Duration::from_secs(1),
         TransformPositionLens {
             start: Vec3::new(-200., 100., 0.),
@@ -149,7 +159,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     .with_completed_event(true, 99); // Get an event once move completed
     let tween_rotate = Tween::new(
         EaseFunction::QuadraticInOut,
-        TweeningType::Once,
         Duration::from_secs(1),
         TransformRotationLens {
             start: Quat::IDENTITY,
@@ -158,7 +167,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
     let tween_scale = Tween::new(
         EaseFunction::QuadraticInOut,
-        TweeningType::Once,
         Duration::from_secs(1),
         TransformScaleLens {
             start: Vec3::ONE,

--- a/examples/sprite_color.rs
+++ b/examples/sprite_color.rs
@@ -68,7 +68,7 @@ fn setup(mut commands: Commands) {
             },
         )
         .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::Bounce);
+        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
 
         commands
             .spawn_bundle(SpriteBundle {

--- a/examples/sprite_color.rs
+++ b/examples/sprite_color.rs
@@ -63,13 +63,14 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
-            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             SpriteColorLens {
                 start: Color::RED,
                 end: Color::BLUE,
             },
-        );
+        )
+        .with_repeat_count(RepeatCount::Infinite)
+        .with_repeat_strategy(RepeatStrategy::Bounce);
 
         commands
             .spawn_bundle(SpriteBundle {

--- a/examples/text_color.rs
+++ b/examples/text_color.rs
@@ -70,14 +70,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ] {
         let tween = Tween::new(
             *ease_function,
-            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             TextColorLens {
                 start: Color::RED,
                 end: Color::BLUE,
                 section: 0,
             },
-        );
+        )
+        .with_repeat_count(RepeatCount::Infinite)
+        .with_repeat_strategy(RepeatStrategy::Bounce);
 
         commands
             .spawn_bundle(TextBundle {

--- a/examples/text_color.rs
+++ b/examples/text_color.rs
@@ -76,7 +76,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
         )
         .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::Bounce);
+        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
 
         commands
             .spawn_bundle(TextBundle {

--- a/examples/transform_rotation.rs
+++ b/examples/transform_rotation.rs
@@ -77,13 +77,14 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
-            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             TransformRotationLens {
                 start: Quat::IDENTITY,
                 end: Quat::from_axis_angle(Vec3::Z, std::f32::consts::PI / 2.),
             },
-        );
+        )
+        .with_repeat_count(RepeatCount::Infinite)
+        .with_repeat_strategy(RepeatStrategy::Bounce);
 
         commands
             .spawn_bundle((

--- a/examples/transform_rotation.rs
+++ b/examples/transform_rotation.rs
@@ -84,7 +84,7 @@ fn setup(mut commands: Commands) {
             },
         )
         .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::Bounce);
+        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
 
         commands
             .spawn_bundle((

--- a/examples/transform_translation.rs
+++ b/examples/transform_translation.rs
@@ -76,13 +76,14 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
-            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             TransformPositionLens {
                 start: Vec3::new(x, screen_y, 0.),
                 end: Vec3::new(x, -screen_y, 0.),
             },
-        );
+        )
+        .with_repeat_count(RepeatCount::Infinite)
+        .with_repeat_strategy(RepeatStrategy::Bounce);
 
         commands
             .spawn_bundle(SpriteBundle {

--- a/examples/transform_translation.rs
+++ b/examples/transform_translation.rs
@@ -83,7 +83,7 @@ fn setup(mut commands: Commands) {
             },
         )
         .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::Bounce);
+        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
 
         commands
             .spawn_bundle(SpriteBundle {

--- a/examples/ui_position.rs
+++ b/examples/ui_position.rs
@@ -93,7 +93,7 @@ fn setup(mut commands: Commands) {
             },
         )
         .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::Bounce);
+        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
 
         commands
             .spawn_bundle(NodeBundle {

--- a/examples/ui_position.rs
+++ b/examples/ui_position.rs
@@ -76,7 +76,6 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
-            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             UiPositionLens {
                 start: Rect {
@@ -92,7 +91,9 @@ fn setup(mut commands: Commands) {
                     bottom: Val::Auto,
                 },
             },
-        );
+        )
+        .with_repeat_count(RepeatCount::Infinite)
+        .with_repeat_strategy(RepeatStrategy::Bounce);
 
         commands
             .spawn_bundle(NodeBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,10 +170,9 @@ pub enum RepeatCount {
 /// What to do when a tween animation needs to be repeated.
 ///
 /// Only applicable when [`RepeatCount`] is greater than 1.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepeatStrategy {
     /// Reset the animation back to its starting position.
-    #[default]
     Teleport,
     /// Follow a ping-pong pattern, changing the direction each time an endpoint is reached.
     ///
@@ -186,6 +185,12 @@ pub enum RepeatStrategy {
 impl Default for RepeatCount {
     fn default() -> Self {
         Self::Finite(1)
+    }
+}
+
+impl Default for RepeatStrategy {
+    fn default() -> Self {
+        Self::Teleport
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,14 +175,14 @@ pub enum RepeatCount {
     /// Run the animation N times.
     Finite(u32),
     /// Run the animation for some amount of time.
-    Until(Duration),
+    For(Duration),
     /// Loop the animation indefinitely.
     Infinite,
 }
 
 /// What to do when a tween animation needs to be repeated.
 ///
-/// Only applicable when [`RepeatCount`] is greater than 1.
+/// Only applicable when [`RepeatCount`] is greater than the animation duration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepeatStrategy {
     /// Reset the animation back to its starting position.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,14 +570,14 @@ mod tests {
 
     #[test]
     fn repeat_count() {
-        let tweening_type = RepeatCount::default();
-        assert_eq!(tweening_type, RepeatCount::Finite(1));
+        let count = RepeatCount::default();
+        assert_eq!(count, RepeatCount::Finite(1));
     }
 
     #[test]
     fn repeat_strategy() {
-        let tweening_type = RepeatStrategy::default();
-        assert_eq!(tweening_type, RepeatStrategy::Teleport);
+        let strategy = RepeatStrategy::default();
+        assert_eq!(strategy, RepeatStrategy::Teleport);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,16 +141,12 @@
 //! [`Sprite`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html
 //! [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
 
-use bevy::{asset::Asset, prelude::*};
 use std::time::Duration;
 
+use bevy::{asset::Asset, prelude::*};
 use interpolation::Ease as IEase;
 pub use interpolation::EaseFunction;
 pub use interpolation::Lerp;
-
-pub mod lens;
-mod plugin;
-mod tweenable;
 
 pub use lens::Lens;
 pub use plugin::{
@@ -159,6 +155,10 @@ pub use plugin::{
 pub use tweenable::{
     BoxedTweenable, Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState, Tweenable,
 };
+
+pub mod lens;
+mod plugin;
+mod tweenable;
 
 /// How many times to repeat a tween animation. See also: [`RepeatMode`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -526,8 +526,9 @@ impl<T: Asset> AssetAnimator<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{lens::*, *};
     use bevy::reflect::TypeUuid;
+
+    use super::{lens::*, *};
 
     struct DummyLens {
         start: f32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,9 +290,8 @@ impl From<EaseFunction> for EaseMethod {
 /// For all but [`RepeatStrategy::Bounce`] this is always
 /// [`TweeningDirection::Forward`], unless manually configured with
 /// [`Tween::set_direction()`] in which case the value is constant equal to the
-/// value set. When using [`RepeatStrategy::Bounce`], this is
-/// either forward (from start to end; ping) or backward (from end to start;
-/// pong), depending
+/// value set. When using [`RepeatStrategy::Bounce`], this is either forward
+/// (from start to end; ping) or backward (from end to start; pong), depending
 /// on the current iteration of the loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TweeningDirection {
@@ -394,8 +393,7 @@ macro_rules! animator_impl {
             }
         }
 
-        /// Get the current progress of
-        /// the tweenable. See [`Tweenable::progress`] for
+        /// Get the current progress of the tweenable. See [`Tweenable::progress`] for
         /// details.
         ///
         /// For sequences, the progress is measured over the entire sequence, from 0 at

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ pub enum RepeatCount {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepeatStrategy {
     /// Reset the animation back to its starting position.
-    Teleport,
+    Repeat,
     /// Follow a ping-pong pattern, changing the direction each time an endpoint
     /// is reached.
     ///
@@ -192,7 +192,7 @@ pub enum RepeatStrategy {
     /// iterations for the various operations where looping matters. That
     /// is, a 1 second animation will take 2 seconds to end up back where it
     /// started.
-    Bounce,
+    MirroredRepeat,
 }
 
 impl Default for RepeatCount {
@@ -203,7 +203,7 @@ impl Default for RepeatCount {
 
 impl Default for RepeatStrategy {
     fn default() -> Self {
-        Self::Teleport
+        Self::Repeat
     }
 }
 
@@ -287,12 +287,12 @@ impl From<EaseFunction> for EaseMethod {
 /// that target at the start bound of the lens, effectively making the animation
 /// play backward.
 ///
-/// For all but [`RepeatStrategy::Bounce`] this is always
+/// For all but [`RepeatStrategy::MirroredRepeat`] this is always
 /// [`TweeningDirection::Forward`], unless manually configured with
 /// [`Tween::set_direction()`] in which case the value is constant equal to the
-/// value set. When using [`RepeatStrategy::Bounce`], this is either forward
-/// (from start to end; ping) or backward (from end to start; pong), depending
-/// on the current iteration of the loop.
+/// value set. When using [`RepeatStrategy::MirroredRepeat`], this is either
+/// forward (from start to end; ping) or backward (from end to start; pong),
+/// depending on the current iteration of the loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TweeningDirection {
     /// Animation playing from start to end.
@@ -577,7 +577,7 @@ mod tests {
     #[test]
     fn repeat_strategy() {
         let strategy = RepeatStrategy::default();
-        assert_eq!(strategy, RepeatStrategy::Teleport);
+        assert_eq!(strategy, RepeatStrategy::Repeat);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,8 @@ mod tweenable;
 pub enum RepeatCount {
     /// Run the animation N times.
     Finite(u32),
+    /// Run the animation for some amount of time.
+    Until(Duration),
     /// Loop the animation indefinitely.
     Infinite,
 }

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1348,10 +1348,6 @@ mod tests {
                 assert_eq!(tracks.times_completed(), 1);
                 assert!((tracks.progress() - 1.).abs() < 1e-5);
                 assert!(transform.translation.abs_diff_eq(Vec3::ONE, 1e-5));
-                dbg!(
-                    transform.rotation,
-                    Quat::from_rotation_x(90_f32.to_radians())
-                );
                 assert!(transform
                     .rotation
                     .abs_diff_eq(Quat::from_rotation_x(90_f32.to_radians()), 1e-5));

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -175,8 +175,7 @@ pub trait Tweenable<T>: Send + Sync {
     ///
     /// Note that for [`RepeatStrategy::Bounce`], this is the duration of a
     /// single way, either from start to end or back from end to start. The
-    /// total "loop" duration start -> end -> start to reach back the same
-    /// state
+    /// total "loop" duration start -> end -> start to reach back the same state
     /// in this case is the double of the returned value.
     fn duration(&self) -> Duration;
 
@@ -222,11 +221,9 @@ pub trait Tweenable<T>: Send + Sync {
     /// Get the number of times this tweenable completed.
     ///
     /// For looping animations, this returns the number of times a single
-    /// playback was completed. In the case of [`RepeatStrategy::Bounce`]
-    /// this
+    /// playback was completed. In the case of [`RepeatStrategy::Bounce`] this
     /// corresponds to a playback in a single direction, so tweening from start
-    /// to end and back to start counts as two completed times (one
-    /// forward, one
+    /// to end and back to start counts as two completed times (one forward, one
     /// backward).
     fn times_completed(&self) -> u32;
 

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -125,6 +125,9 @@ impl AnimClock {
 
         let before = self.elapsed.as_nanos() / duration;
         self.elapsed = self.elapsed.saturating_add(tick);
+        if let TotalDuration::Finite(duration) = self.total_duration {
+            self.elapsed = self.elapsed.min(duration);
+        }
         (self.elapsed.as_nanos() / duration - before) as u32
     }
 
@@ -871,6 +874,7 @@ mod tests {
     fn anim_clock_precision() {
         let duration = Duration::from_millis(1);
         let mut clock = AnimClock::new(duration);
+        clock.total_duration = TotalDuration::Infinite;
 
         let test_ticks = [
             Duration::from_micros(123),
@@ -1344,6 +1348,10 @@ mod tests {
                 assert_eq!(tracks.times_completed(), 1);
                 assert!((tracks.progress() - 1.).abs() < 1e-5);
                 assert!(transform.translation.abs_diff_eq(Vec3::ONE, 1e-5));
+                dbg!(
+                    transform.rotation,
+                    Quat::from_rotation_x(90_f32.to_radians())
+                );
                 assert!(transform
                     .rotation
                     .abs_diff_eq(Quat::from_rotation_x(90_f32.to_radians()), 1e-5));

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -404,24 +404,24 @@ impl<T> Tween<T> {
         self
     }
 
-    /// TODO
+    /// Set the number of times to repeat the animation.
     pub fn set_repeat_count(&mut self, count: RepeatCount) {
         self.completion.count = count;
     }
 
-    /// TODO
+    /// Set the number of times to repeat the animation.
     #[must_use]
     pub fn with_repeat_count(mut self, count: RepeatCount) -> Self {
         self.completion.count = count;
         self
     }
 
-    /// TODO
+    /// Choose how the animation behaves upon a repetition.
     pub fn set_repeat_strategy(&mut self, strategy: RepeatStrategy) {
         self.completion.strategy = strategy;
     }
 
-    /// TODO
+    /// Choose how the animation behaves upon a repetition.
     #[must_use]
     pub fn with_repeat_strategy(mut self, strategy: RepeatStrategy) -> Self {
         self.completion.strategy = strategy;

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -404,6 +404,14 @@ impl<T> Tween<T> {
         self
     }
 
+    /// The current animation direction.
+    ///
+    /// See [`TweeningDirection`] for details.
+    #[must_use]
+    pub fn direction(&self) -> TweeningDirection {
+        self.direction
+    }
+
     /// Set the number of times to repeat the animation.
     pub fn set_repeat_count(&mut self, count: RepeatCount) {
         self.completion.count = count;
@@ -426,14 +434,6 @@ impl<T> Tween<T> {
     pub fn with_repeat_strategy(mut self, strategy: RepeatStrategy) -> Self {
         self.completion.strategy = strategy;
         self
-    }
-
-    /// The current animation direction.
-    ///
-    /// See [`TweeningDirection`] for details.
-    #[must_use]
-    pub fn direction(&self) -> TweeningDirection {
-        self.direction
     }
 
     /// Set a callback invoked when the animation completed.

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -167,7 +167,7 @@ enum TotalDuration {
 fn compute_total_duration(duration: Duration, count: RepeatCount) -> TotalDuration {
     match count {
         RepeatCount::Finite(times) => TotalDuration::Finite(duration.saturating_mul(times)),
-        RepeatCount::Until(duration) => TotalDuration::Finite(duration),
+        RepeatCount::For(duration) => TotalDuration::Finite(duration),
         RepeatCount::Infinite => TotalDuration::Infinite,
     }
 }
@@ -1055,7 +1055,7 @@ mod tests {
                                     )
                                 }
                             }
-                            RepeatCount::Until(_) => panic!("Untested"),
+                            RepeatCount::For(_) => panic!("Untested"),
                         };
                     let factor = if tweening_direction.is_backward() {
                         direction = !direction;


### PR DESCRIPTION
Fixes #17

This supports an animation like the following:

```rust
pub fn error_shake(current: &Transform) -> Sequence<Transform> {
    let wiggle = Quat::from_rotation_z(PI / 16.);
    Tween::new(
        EaseMethod::Linear,
        TweeningType::Once,
        Duration::from_millis(25),
        TransformRotationLens {
            start: current.rotation,
            end: current.rotation * wiggle.inverse(),
        },
    )
    .then(Tween::new(
        EaseMethod::Linear,
        TweeningType::PingPongTimes(3),
        Duration::from_millis(50),
        TransformRotationLens {
            start: current.rotation * wiggle.inverse(),
            end: current.rotation * wiggle,
        },
    ))
    .then(Tween::new(
        EaseMethod::Linear,
        TweeningType::Once,
        Duration::from_millis(25),
        TransformRotationLens {
            start: current.rotation * wiggle,
            end: current.rotation,
        },
    ))
}
```