### PR TITLE
Fix questionable use of floats and re-work all ticking logic 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ bevy = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 bevy-inspector-egui = "0.10"
+itertools = "0.10.3"
 
 [[example]]
 name = "menu"


### PR DESCRIPTION
What's broken?
- Float usage inconsistently used f64 or f32. I changed everything to be f32 since precision isn't really the priority in games.
- Float rounding issues were present in several places. For example, the AnimClock never reset the elapsed time leading to a continual loss of precision as the animation progressed.
- Sequences did not handle deltas that crossed animation boundaries. This meant that if a one-hour delta was received, only one animation would complete instead of all of them.
- I tried to simplify all the other logic in the process while improving performance.