### PR TITLE
Optimize out allocations as much as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Tween::set_direction()` and `Tween::with_direction()` which allow configuring the playback direction of a tween, allowing to play it backward from end to start.
 - Support dynamically changing an animation's speed with `Animator::set_speed`
 - Add `AnimationSystem` label to tweening tick systems
+- A `BoxedTweenable` type to make working with `Box<dyn Tweenable + ...>` easier
+
+### Changed
+
+- Double boxing in `Sequence` and `Tracks` was fixed. As a result, any custom tweenables
+  should implement `From` for `BoxedTweenable` to make those APIs easier to use.
 
 ## [0.4.0] - 2022-04-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ bevy_ui = ["bevy/bevy_ui", "bevy/bevy_text", "bevy/bevy_render"]
 [dependencies]
 interpolation = "0.2"
 bevy = { version = "0.7", default-features = false }
-smallvec = "1.8.0"
 
 [dev-dependencies]
 bevy-inspector-egui = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bevy_ui = ["bevy/bevy_ui", "bevy/bevy_text", "bevy/bevy_render"]
 [dependencies]
 interpolation = "0.2"
 bevy = { version = "0.7", default-features = false }
+smallvec = "1.8.0"
 
 [dev-dependencies]
 bevy-inspector-egui = "0.10"

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -167,7 +167,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tracks = Tracks::new([tween_rotate, tween_scale]);
     // Build a sequence from an heterogeneous list of tweenables by casting them manually
     // to a boxed Tweenable<Transform> : first move, then { rotate + scale }.
-    let seq2 = Sequence::new([DynTweenable::from(tween_move), tracks.into()]);
+    let seq2 = Sequence::new([Box::new(tween_move) as BoxedTweenable<_>, tracks.into()]);
 
     commands
         .spawn_bundle(SpriteBundle {

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -167,10 +167,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let tracks = Tracks::new([tween_rotate, tween_scale]);
     // Build a sequence from an heterogeneous list of tweenables by casting them manually
     // to a boxed Tweenable<Transform> : first move, then { rotate + scale }.
-    let seq2 = Sequence::new([
-        Box::new(tween_move) as Box<dyn Tweenable<Transform> + Send + Sync + 'static>,
-        Box::new(tracks) as Box<dyn Tweenable<Transform> + Send + Sync + 'static>,
-    ]);
+    let seq2 = Sequence::new([DynTweenable::from(tween_move), tracks.into()]);
 
     commands
         .spawn_bundle(SpriteBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,10 @@ pub use lens::Lens;
 pub use plugin::{
     asset_animator_system, component_animator_system, AnimationSystem, TweeningPlugin,
 };
-pub use tweenable::{Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState, Tweenable};
+pub use tweenable::{
+    BoxedTweenable, Delay, DynTweenable, Sequence, Tracks, Tween, TweenCompleted, TweenState,
+    Tweenable,
+};
 
 /// Type of looping for a tween animation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -427,7 +430,7 @@ macro_rules! animator_impl {
 pub struct Animator<T: Component> {
     /// Control if this animation is played or not.
     pub state: AnimatorState,
-    tweenable: Option<Box<dyn Tweenable<T> + Send + Sync + 'static>>,
+    tweenable: Option<BoxedTweenable<T>>,
     speed: f32,
 }
 
@@ -467,7 +470,7 @@ impl<T: Component> Animator<T> {
 pub struct AssetAnimator<T: Asset> {
     /// Control if this animation is played or not.
     pub state: AnimatorState,
-    tweenable: Option<Box<dyn Tweenable<T> + Send + Sync + 'static>>,
+    tweenable: Option<BoxedTweenable<T>>,
     handle: Handle<T>,
     speed: f32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,8 +162,7 @@ pub use plugin::{
     asset_animator_system, component_animator_system, AnimationSystem, TweeningPlugin,
 };
 pub use tweenable::{
-    BoxedTweenable, Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState,
-    Tweenable,
+    BoxedTweenable, Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState, Tweenable,
 };
 
 /// Type of looping for a tween animation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub use plugin::{
     asset_animator_system, component_animator_system, AnimationSystem, TweeningPlugin,
 };
 pub use tweenable::{
-    BoxedTweenable, Delay, DynTweenable, Sequence, Tracks, Tween, TweenCompleted, TweenState,
+    BoxedTweenable, Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState,
     Tweenable,
 };
 

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -207,7 +207,7 @@ impl<T> Tweenable<T> for BoxedTweenable<T> {
 /// You should only ever use [`DynTweenable::from`][From::from].
 ///
 /// When using your own [`Tweenable`]s, convert them to a box first:
-/// ```no_run
+/// ```
 /// # use std::time::Duration;
 /// # use bevy::prelude::{Entity, EventWriter, Transform};
 /// # use bevy_tweening::{BoxedTweenable, DynTweenable, Tweenable, TweenCompleted, TweenState};
@@ -224,6 +224,16 @@ impl<T> Tweenable<T> for BoxedTweenable<T> {
 /// # }
 ///
 /// DynTweenable::from(Box::new(MyTweenable) as BoxedTweenable<_>);
+///
+/// // OR
+///
+/// DynTweenable::from(MyTweenable);
+///
+/// impl From<MyTweenable> for DynTweenable<Transform> {
+///     fn from(t: MyTweenable) -> Self {
+///         DynTweenable::from(Box::new(t) as BoxedTweenable<_>)
+///     }
+/// }
 /// ```
 pub enum DynTweenable<T> {
     #[doc(hidden)]

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -541,7 +541,7 @@ impl<T> Sequence<T> {
     #[must_use]
     pub fn from_single(tween: impl Tweenable<T> + Send + Sync + 'static) -> Self {
         let duration = tween.duration();
-        let boxed: BoxedTweenable<T> = tween.into();
+        let boxed: BoxedTweenable<T> = Box::new(tween);
         Self {
             tweens: vec![boxed],
             index: 0,

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -248,42 +248,40 @@ pub enum DynTweenable<T> {
     Tween(Tween<T>),
 }
 
+impl<T> DynTweenable<T> {
+    fn as_dyn(&self) -> &dyn Tweenable<T> {
+        match self {
+            Self::Boxed(b) => b,
+            Self::Delay(d) => d,
+            Self::Sequence(s) => s,
+            Self::Tracks(t) => t,
+            Self::Tween(t) => t,
+        }
+    }
+
+    fn as_mut_dyn(&mut self) -> &mut dyn Tweenable<T> {
+        match self {
+            Self::Boxed(b) => b,
+            Self::Delay(d) => d,
+            Self::Sequence(s) => s,
+            Self::Tracks(t) => t,
+            Self::Tween(t) => t,
+        }
+    }
+}
+
 impl<T> Tweenable<T> for DynTweenable<T> {
     fn duration(&self) -> Duration {
-        match self {
-            Self::Boxed(b) => b.duration(),
-            Self::Delay(d) => Tweenable::<T>::duration(d),
-            Self::Sequence(s) => s.duration(),
-            Self::Tracks(t) => t.duration(),
-            Self::Tween(t) => t.duration(),
-        }
+        self.as_dyn().duration()
     }
     fn is_looping(&self) -> bool {
-        match self {
-            Self::Boxed(b) => b.is_looping(),
-            Self::Delay(d) => Tweenable::<T>::is_looping(d),
-            Self::Sequence(s) => s.is_looping(),
-            Self::Tracks(t) => t.is_looping(),
-            Self::Tween(t) => t.is_looping(),
-        }
+        self.as_dyn().is_looping()
     }
     fn set_progress(&mut self, progress: f32) {
-        match self {
-            Self::Boxed(b) => b.set_progress(progress),
-            Self::Delay(d) => Tweenable::<T>::set_progress(d, progress),
-            Self::Sequence(s) => s.set_progress(progress),
-            Self::Tracks(t) => t.set_progress(progress),
-            Self::Tween(t) => t.set_progress(progress),
-        }
+        self.as_mut_dyn().set_progress(progress);
     }
     fn progress(&self) -> f32 {
-        match self {
-            Self::Boxed(b) => b.progress(),
-            Self::Delay(d) => Tweenable::<T>::progress(d),
-            Self::Sequence(s) => s.progress(),
-            Self::Tracks(t) => t.progress(),
-            Self::Tween(t) => t.progress(),
-        }
+        self.as_dyn().progress()
     }
     fn tick(
         &mut self,
@@ -292,31 +290,13 @@ impl<T> Tweenable<T> for DynTweenable<T> {
         entity: Entity,
         event_writer: &mut EventWriter<TweenCompleted>,
     ) -> TweenState {
-        match self {
-            Self::Boxed(b) => b.tick(delta, target, entity, event_writer),
-            Self::Delay(d) => d.tick(delta, target, entity, event_writer),
-            Self::Sequence(s) => s.tick(delta, target, entity, event_writer),
-            Self::Tracks(t) => t.tick(delta, target, entity, event_writer),
-            Self::Tween(t) => t.tick(delta, target, entity, event_writer),
-        }
+        self.as_mut_dyn().tick(delta, target, entity, event_writer)
     }
     fn times_completed(&self) -> u32 {
-        match self {
-            Self::Boxed(b) => b.times_completed(),
-            Self::Delay(d) => Tweenable::<T>::times_completed(d),
-            Self::Sequence(s) => s.times_completed(),
-            Self::Tracks(t) => t.times_completed(),
-            Self::Tween(t) => t.times_completed(),
-        }
+        self.as_dyn().times_completed()
     }
     fn rewind(&mut self) {
-        match self {
-            Self::Boxed(b) => b.rewind(),
-            Self::Delay(d) => Tweenable::<T>::rewind(d),
-            Self::Sequence(s) => s.rewind(),
-            Self::Tracks(t) => t.rewind(),
-            Self::Tween(t) => t.rewind(),
-        }
+        self.as_mut_dyn().rewind();
     }
 }
 
@@ -686,13 +666,7 @@ impl<T> Sequence<T> {
     /// Get the current active tween in the sequence.
     #[must_use]
     pub fn current(&self) -> &dyn Tweenable<T> {
-        match &self.tweens[self.index()] {
-            DynTweenable::Boxed(b) => b.as_ref(),
-            DynTweenable::Delay(d) => d,
-            DynTweenable::Sequence(s) => s,
-            DynTweenable::Tracks(t) => t,
-            DynTweenable::Tween(t) => t,
-        }
+        self.tweens[self.index()].as_dyn()
     }
 }
 

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1,5 +1,6 @@
-use bevy::prelude::*;
 use std::time::Duration;
+
+use bevy::prelude::*;
 
 use crate::{EaseMethod, Lens, TweeningDirection, TweeningType};
 
@@ -206,7 +207,24 @@ impl<T> Tweenable<T> for BoxedTweenable<T> {
 /// You should only ever use [`DynTweenable::from`][From::from].
 ///
 /// When using your own [`Tweenable`]s, convert them to a box first:
-/// `DynTweenable::from(Box::new(my_tweenable) as BoxedTweenable<_>)`.
+/// ```no_run
+/// # use std::time::Duration;
+/// # use bevy::prelude::{Entity, EventWriter, Transform};
+/// # use bevy_tweening::{BoxedTweenable, DynTweenable, Tweenable, TweenCompleted, TweenState};
+/// #
+/// # struct MyTweenable;
+/// # impl Tweenable<Transform> for MyTweenable {
+/// #     fn duration(&self) -> Duration  { unimplemented!() }
+/// #     fn is_looping(&self) -> bool  { unimplemented!() }
+/// #     fn set_progress(&mut self, progress: f32)  { unimplemented!() }
+/// #     fn progress(&self) -> f32  { unimplemented!() }
+/// #     fn tick(&mut self, delta: Duration, target: &mut Transform, entity: Entity, event_writer: &mut EventWriter<TweenCompleted>) -> TweenState  { unimplemented!() }
+/// #     fn times_completed(&self) -> u32  { unimplemented!() }
+/// #     fn rewind(&mut self) { unimplemented!() }
+/// # }
+///
+/// DynTweenable::from(Box::new(MyTweenable) as BoxedTweenable<_>);
+/// ```
 pub enum DynTweenable<T> {
     #[doc(hidden)]
     Boxed(BoxedTweenable<T>),
@@ -908,11 +926,14 @@ impl<T> Tweenable<T> for Delay {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::lens::*;
-    use bevy::ecs::{event::Events, system::SystemState};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
+
+    use bevy::ecs::{event::Events, system::SystemState};
+
+    use crate::lens::*;
+
+    use super::*;
 
     /// Utility to compare floating-point values with a tolerance.
     fn abs_diff_eq(a: f32, b: f32, tol: f32) -> bool {

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -17,6 +17,36 @@ use crate::{EaseMethod, Lens, TweeningDirection, TweeningType};
 ///
 /// Sequence::new([Box::new(delay) as BoxedTweenable<Transform>, tween.into()]);
 /// ```
+///
+/// When using your own [`Tweenable`] types, APIs will be easier to use if you implement [`From`]:
+/// ```no_run
+/// # use std::time::Duration;
+/// # use bevy::prelude::{Entity, EventWriter, Transform};
+/// # use bevy_tweening::{BoxedTweenable, Sequence, Tweenable, TweenCompleted, TweenState};
+/// #
+/// # struct MyTweenable;
+/// # impl Tweenable<Transform> for MyTweenable {
+/// #     fn duration(&self) -> Duration  { unimplemented!() }
+/// #     fn is_looping(&self) -> bool  { unimplemented!() }
+/// #     fn set_progress(&mut self, progress: f32)  { unimplemented!() }
+/// #     fn progress(&self) -> f32  { unimplemented!() }
+/// #     fn tick(&mut self, delta: Duration, target: &mut Transform, entity: Entity, event_writer: &mut EventWriter<TweenCompleted>) -> TweenState  { unimplemented!() }
+/// #     fn times_completed(&self) -> u32  { unimplemented!() }
+/// #     fn rewind(&mut self) { unimplemented!() }
+/// # }
+///
+/// Sequence::new([Box::new(MyTweenable) as BoxedTweenable<_>]);
+///
+/// // OR
+///
+/// Sequence::new([MyTweenable]);
+///
+/// impl From<MyTweenable> for BoxedTweenable<Transform> {
+///     fn from(t: MyTweenable) -> Self {
+///         Box::new(t)
+///     }
+/// }
+/// ```
 pub type BoxedTweenable<T> = Box<dyn Tweenable<T> + Send + Sync + 'static>;
 
 /// Playback state of a [`Tweenable`].

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -541,7 +541,7 @@ impl<T> Sequence<T> {
     #[must_use]
     pub fn from_single(tween: impl Tweenable<T> + Send + Sync + 'static) -> Self {
         let duration = tween.duration();
-        let boxed: BoxedTweenable<T> = Box::new(tween);
+        let boxed: BoxedTweenable<T> = tween.into();
         Self {
             tweens: vec![boxed],
             index: 0,


### PR DESCRIPTION
Current paint points:
- All tweenables in sequences and tracks are allocated even though most people will primarily use the built-ins.
- There's double boxing causing extreme indirection: tweenables are stored in a vec which contains boxes of boxes (since `IntoBoxDynTweenable` unconditionally boxes and there's no way to avoid this without specialization which is a long ways away).
- Creating seqs/tracks of heterogeneous types is very ugly and confusing.

Solutions:
- Use an enum to fake dynamic typing for built-ins.
- Provide an impl for boxed types for 3P tweenables.
- Export a BoxedTweenable type to alleviate typing pain.

This makes built-ins zero cost while 3P types only suffer one layer of indirection.

Closes #28