### PR TITLE
Add `BoxedTweenable<T>` and avoid double boxing

### DIFF
--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -168,10 +168,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Build parallel tracks executing two tweens at the same time : rotate and scale.
     let tracks = Tracks::new([tween_rotate, tween_scale]);
     // Build a sequence from an heterogeneous list of tweenables by casting them manually
-    // to a boxed Tweenable<Transform> : first move, then { rotate + scale }.
-    let seq2 = Sequence::new([
-        Box::new(tween_move) as Box<dyn Tweenable<Transform> + Send + Sync + 'static>,
-        Box::new(tracks) as Box<dyn Tweenable<Transform> + Send + Sync + 'static>,
+    // to a BoxedTweenable<Transform> : first move, then { rotate + scale }.
+    let seq2 = Sequence::from_vec(vec![
+        Box::new(tween_move) as BoxedTweenable<Transform>,
+        Box::new(tracks) as BoxedTweenable<Transform>,
     ]);
 
     commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,10 @@ pub use lens::Lens;
 pub use plugin::{
     asset_animator_system, component_animator_system, AnimationSystem, TweeningPlugin,
 };
-pub use tweenable::{Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState, Tweenable};
+pub use tweenable::{
+    BoxedTweenable, Delay, IntoBoxedTweenable, Sequence, Tracks, Tween, TweenCompleted, TweenState,
+    Tweenable,
+};
 
 /// Type of looping for a tween animation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Add a type alias `BoxedTweenable<T>` for brevity, and rename
`IntoBoxDynTweenable<T>` to `IntoBoxedTweenable<T>` for consistency, as
well as the trait method to `into_boxed()`.

Remove the `impl<T> Tweenable<T> for BoxedTweenable<T>` to prevent
silent double-boxing when passing an already-boxed collection to
`Sequence::new()`.

Instead, add a new `Sequence::from_vec()` taking a `Vec<>` of boxed
tweenables directly, which shall replace any prior use of `new()` that
would have double-boxed items.