### PR TITLE
Update to bevy 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ bevy_ui = ["bevy/bevy_ui", "bevy/bevy_text", "bevy/bevy_render"]
 
 [dependencies]
 interpolation = "0.2"
-bevy = { version = "0.7", default-features = false }
+bevy = { version = "0.8", default-features = false, features = ["bevy_asset"] }
 
-[dev-dependencies]
-bevy-inspector-egui = "0.10"
+# [dev-dependencies]
+# bevy-inspector-egui = "0.11"
 
 [[example]]
 name = "menu"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@ criterion = { version = "0.3", features = ["html_reports"] }
 bevy_tweening = { path = "../" }
 
 [dependencies.bevy]
-version = "0.6"
+version = "0.8"
 default-features = false
 features = [ "render" ]
 

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -293,9 +293,9 @@ impl Lens<Transform> for TransformScaleLens {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiPositionLens {
     /// Start position.
-    pub start: Rect<Val>,
+    pub start: UiRect<Val>,
     /// End position.
-    pub end: Rect<Val>,
+    pub end: UiRect<Val>,
 }
 
 #[cfg(feature = "bevy_ui")]
@@ -312,7 +312,7 @@ fn lerp_val(start: &Val, end: &Val, ratio: f32) -> Val {
 #[cfg(feature = "bevy_ui")]
 impl Lens<Style> for UiPositionLens {
     fn lerp(&mut self, target: &mut Style, ratio: f32) {
-        target.position = Rect {
+        target.position = UiRect {
             left: lerp_val(&self.start.left, &self.end.left, ratio),
             right: lerp_val(&self.start.right, &self.end.right, ratio),
             top: lerp_val(&self.start.top, &self.end.top, ratio),

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,4 +1,5 @@
-use bevy::{asset::Asset, ecs::component::Component, prelude::*};
+use bevy::asset::Asset;
+use bevy::{ecs::component::Component, prelude::*};
 
 use crate::{Animator, AnimatorState, AssetAnimator, TweenCompleted};
 
@@ -86,7 +87,7 @@ pub fn asset_animator_system<T: Asset>(
 ) {
     for (entity, ref mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
-            if let Some(target) = assets.get_mut(animator.handle()) {
+            if let Some(target) = assets.get_mut(&animator.handle()) {
                 animator.tick(time.delta(), target, entity, &mut event_writer);
             }
         }


### PR DESCRIPTION
bevy 0.8 has just been released and I would love to use bevy_tweening with it. I've successfully been using these changes with a local copy. `bevy-inspector-egui` does not have a compatible release yet, unfortunately. 