### PR TITLE
Get rid of Optional tween

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed the `tweening_type` parameter from the signature of `Tween<T>::new()`; use `with_repeat_count()` and `with_repeat_strategy()` instead.
+- Animators now always have a tween (instead of it being optional). This means the default animator implementation was removed.
 
 ### Removed
 

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -203,11 +203,11 @@ fn update_text(
     mut query_event: EventReader<TweenCompleted>,
 ) {
     let anim_red = query_anim_red.single();
-    let tween_red = anim_red.tweenable().unwrap();
+    let tween_red = anim_red.tweenable();
     let progress_red = tween_red.progress();
 
     let anim_blue = query_anim_blue.single();
-    let tween_blue = anim_blue.tweenable().unwrap();
+    let tween_blue = anim_blue.tweenable();
     let progress_blue = tween_blue.progress();
 
     let mut red_text = query_text_red.single_mut();

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -203,12 +203,10 @@ fn update_text(
     mut query_event: EventReader<TweenCompleted>,
 ) {
     let anim_red = query_anim_red.single();
-    let tween_red = anim_red.tweenable();
-    let progress_red = tween_red.progress();
+    let progress_red = anim_red.progress();
 
     let anim_blue = query_anim_blue.single();
-    let tween_blue = anim_blue.tweenable();
-    let progress_blue = tween_blue.progress();
+    let progress_blue = anim_blue.progress();
 
     let mut red_text = query_text_red.single_mut();
     red_text.sections[1].value = format!("{:5.1}%", progress_red * 100.);

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -203,10 +203,10 @@ fn update_text(
     mut query_event: EventReader<TweenCompleted>,
 ) {
     let anim_red = query_anim_red.single();
-    let progress_red = anim_red.progress();
+    let progress_red = anim_red.tweenable().progress();
 
     let anim_blue = query_anim_blue.single();
-    let progress_blue = anim_blue.progress();
+    let progress_blue = anim_blue.tweenable().progress();
 
     let mut red_text = query_text_red.single_mut();
     red_text.sections[1].value = format!("{:5.1}%", progress_red * 100.);

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -373,8 +373,9 @@ impl Lens<Sprite> for SpriteColorLens {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::f32::consts::TAU;
+
+    use super::*;
 
     #[cfg(feature = "bevy_ui")]
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,22 +159,20 @@ use std::{
 #[cfg(feature = "bevy_asset")]
 use bevy::asset::Asset;
 use bevy::prelude::*;
-
 use interpolation::Ease as IEase;
 pub use interpolation::{EaseFunction, Lerp};
 
-pub mod lens;
-mod plugin;
-mod tweenable;
-
 pub use lens::Lens;
+#[cfg(feature = "bevy_asset")]
+pub use plugin::asset_animator_system;
 pub use plugin::{component_animator_system, AnimationSystem, TweeningPlugin};
 pub use tweenable::{
     BoxedTweenable, Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState, Tweenable,
 };
 
-#[cfg(feature = "bevy_asset")]
-pub use plugin::asset_animator_system;
+pub mod lens;
+mod plugin;
+mod tweenable;
 
 /// How many times to repeat a tween animation. See also: [`RepeatStrategy`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,71 +361,19 @@ macro_rules! animator_impl {
 
         /// Set the top-level tweenable item this animator controls.
         pub fn set_tweenable(&mut self, tween: impl Tweenable<T> + Send + Sync + 'static) {
-            self.tweenable = Some(Box::new(tween));
+            self.tweenable = Box::new(tween);
         }
 
         /// Get the top-level tweenable this animator is currently controlling.
         #[must_use]
-        pub fn tweenable(&self) -> Option<&(dyn Tweenable<T> + Send + Sync + 'static)> {
-            if let Some(tweenable) = &self.tweenable {
-                Some(tweenable.as_ref())
-            } else {
-                None
-            }
+        pub fn tweenable(&self) -> &(dyn Tweenable<T> + Send + Sync + 'static) {
+            self.tweenable.as_ref()
         }
 
         /// Get the top-level mutable tweenable this animator is currently controlling.
         #[must_use]
-        pub fn tweenable_mut(&mut self) -> Option<&mut (dyn Tweenable<T> + Send + Sync + 'static)> {
-            if let Some(tweenable) = &mut self.tweenable {
-                Some(tweenable.as_mut())
-            } else {
-                None
-            }
-        }
-
-        /// Set the current animation playback progress.
-        ///
-        /// See [`progress()`] for details on the meaning.
-        ///
-        /// [`progress()`]: Animator::progress
-        pub fn set_progress(&mut self, progress: f32) {
-            if let Some(tweenable) = &mut self.tweenable {
-                tweenable.set_progress(progress)
-            }
-        }
-
-        /// Get the current progress of the tweenable. See [`Tweenable::progress`] for
-        /// details.
-        ///
-        /// For sequences, the progress is measured over the entire sequence, from 0 at
-        /// the start of the first child tweenable to 1 at the end of the last one.
-        ///
-        /// For tracks (parallel execution), the progress is measured like a sequence
-        /// over the longest "path" of child tweenables. In other words, this is the
-        /// current elapsed time over the total tweenable duration.
-        #[must_use]
-        pub fn progress(&self) -> f32 {
-            if let Some(tweenable) = &self.tweenable {
-                tweenable.progress()
-            } else {
-                0.
-            }
-        }
-
-        /// Ticks the tween, if present. See [`Tweenable::tick`] for details.
-        pub fn tick(
-            &mut self,
-            delta: Duration,
-            target: &mut T,
-            entity: Entity,
-            event_writer: &mut EventWriter<TweenCompleted>,
-        ) -> Option<TweenState> {
-            if let Some(tweenable) = &mut self.tweenable {
-                Some(tweenable.tick(delta.mul_f32(self.speed), target, entity, event_writer))
-            } else {
-                None
-            }
+        pub fn tweenable_mut(&mut self) -> &mut (dyn Tweenable<T> + Send + Sync + 'static) {
+            self.tweenable.as_mut()
         }
 
         /// Stop animation playback and rewind the animation.
@@ -434,16 +382,7 @@ macro_rules! animator_impl {
         /// tweenable.
         pub fn stop(&mut self) {
             self.state = AnimatorState::Paused;
-            self.rewind();
-        }
-
-        /// Rewind animation playback to its initial state.
-        ///
-        /// This does not change the playback state (playing/paused).
-        pub fn rewind(&mut self) {
-            if let Some(tweenable) = &mut self.tweenable {
-                tweenable.rewind();
-            }
+            self.tweenable_mut().rewind();
         }
     };
 }
@@ -453,7 +392,7 @@ macro_rules! animator_impl {
 pub struct Animator<T: Component> {
     /// Control if this animation is played or not.
     pub state: AnimatorState,
-    tweenable: Option<BoxedTweenable<T>>,
+    tweenable: BoxedTweenable<T>,
     speed: f32,
 }
 
@@ -465,23 +404,14 @@ impl<T: Component + std::fmt::Debug> std::fmt::Debug for Animator<T> {
     }
 }
 
-impl<T: Component> Default for Animator<T> {
-    fn default() -> Self {
-        Self {
-            state: default(),
-            tweenable: None,
-            speed: 1.,
-        }
-    }
-}
-
 impl<T: Component> Animator<T> {
     /// Create a new animator component from a single tweenable.
     #[must_use]
     pub fn new(tween: impl Tweenable<T> + Send + Sync + 'static) -> Self {
         Self {
-            tweenable: Some(Box::new(tween)),
-            ..default()
+            state: default(),
+            tweenable: Box::new(tween),
+            speed: 1.,
         }
     }
 
@@ -493,7 +423,7 @@ impl<T: Component> Animator<T> {
 pub struct AssetAnimator<T: Asset> {
     /// Control if this animation is played or not.
     pub state: AnimatorState,
-    tweenable: Option<BoxedTweenable<T>>,
+    tweenable: BoxedTweenable<T>,
     handle: Handle<T>,
     speed: f32,
 }
@@ -506,25 +436,15 @@ impl<T: Asset + std::fmt::Debug> std::fmt::Debug for AssetAnimator<T> {
     }
 }
 
-impl<T: Asset> Default for AssetAnimator<T> {
-    fn default() -> Self {
-        Self {
-            state: default(),
-            tweenable: None,
-            handle: default(),
-            speed: 1.,
-        }
-    }
-}
-
 impl<T: Asset> AssetAnimator<T> {
     /// Create a new asset animator component from a single tweenable.
     #[must_use]
     pub fn new(handle: Handle<T>, tween: impl Tweenable<T> + Send + Sync + 'static) -> Self {
         Self {
-            tweenable: Some(Box::new(tween)),
+            state: default(),
+            tweenable: Box::new(tween),
             handle,
-            ..default()
+            speed: 1.,
         }
     }
 
@@ -624,7 +544,6 @@ mod tests {
         assert_eq!(1., ease.sample(0.));
     }
 
-    /// Animator::new()
     #[test]
     fn animator_new() {
         let tween = Tween::new(
@@ -634,11 +553,10 @@ mod tests {
         );
         let animator = Animator::<DummyComponent>::new(tween);
         assert_eq!(animator.state, AnimatorState::default());
-        let tween = animator.tweenable().unwrap();
+        let tween = animator.tweenable();
         assert_eq!(tween.progress(), 0.);
     }
 
-    /// Animator::with_state()
     #[test]
     fn animator_with_state() {
         for state in [AnimatorState::Playing, AnimatorState::Paused] {
@@ -652,24 +570,6 @@ mod tests {
         }
     }
 
-    /// Animator::default() + Animator::set_tweenable()
-    #[test]
-    fn animator_default() {
-        let mut animator = Animator::<DummyComponent>::default();
-        assert!(animator.tweenable().is_none());
-        assert!(animator.tweenable_mut().is_none());
-
-        let tween = Tween::<DummyComponent>::new(
-            EaseFunction::QuadraticInOut,
-            Duration::from_secs(1),
-            DummyLens { start: 0., end: 1. },
-        );
-        animator.set_tweenable(tween);
-        assert!(animator.tweenable().is_some());
-        assert!(animator.tweenable_mut().is_some());
-    }
-
-    /// Animator control playback
     #[test]
     fn animator_controls() {
         let tween = Tween::<DummyComponent>::new(
@@ -679,35 +579,34 @@ mod tests {
         );
         let mut animator = Animator::new(tween);
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
-        animator.set_progress(0.5);
+        animator.tweenable_mut().set_progress(0.5);
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!((animator.progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
 
-        animator.rewind();
+        animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
-        animator.set_progress(0.5);
+        animator.tweenable_mut().set_progress(0.5);
         animator.state = AnimatorState::Playing;
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!((animator.progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
 
-        animator.rewind();
+        animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
     }
 
-    /// AssetAnimator::new()
     #[test]
     fn asset_animator_new() {
         let tween = Tween::<DummyAsset>::new(
@@ -717,11 +616,11 @@ mod tests {
         );
         let animator = AssetAnimator::new(Handle::<DummyAsset>::default(), tween);
         assert_eq!(animator.state, AnimatorState::default());
-        let tween = animator.tweenable().unwrap();
+        assert_eq!(animator.handle(), Handle::<DummyAsset>::default());
+        let tween = animator.tweenable();
         assert_eq!(tween.progress(), 0.);
     }
 
-    /// AssetAnimator::with_state()
     #[test]
     fn asset_animator_with_state() {
         for state in [AnimatorState::Playing, AnimatorState::Paused] {
@@ -736,26 +635,6 @@ mod tests {
         }
     }
 
-    /// AssetAnimator::default() + AssetAnimator::set_tweenable()
-    #[test]
-    fn asset_animator_default() {
-        let mut animator = AssetAnimator::<DummyAsset>::default();
-        assert!(animator.tweenable().is_none());
-        assert!(animator.tweenable_mut().is_none());
-        assert_eq!(animator.handle(), Handle::<DummyAsset>::default());
-
-        let tween = Tween::new(
-            EaseFunction::QuadraticInOut,
-            Duration::from_secs(1),
-            DummyLens { start: 0., end: 1. },
-        );
-        animator.set_tweenable(tween);
-        assert!(animator.tweenable().is_some());
-        assert!(animator.tweenable_mut().is_some());
-        assert_eq!(animator.handle(), Handle::<DummyAsset>::default());
-    }
-
-    /// AssetAnimator control playback
     #[test]
     fn asset_animator_controls() {
         let tween = Tween::new(
@@ -765,31 +644,31 @@ mod tests {
         );
         let mut animator = AssetAnimator::new(Handle::<DummyAsset>::default(), tween);
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
-        animator.set_progress(0.5);
+        animator.tweenable_mut().set_progress(0.5);
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!((animator.progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
 
-        animator.rewind();
+        animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
-        animator.set_progress(0.5);
+        animator.tweenable_mut().set_progress(0.5);
         animator.state = AnimatorState::Playing;
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!((animator.progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
 
-        animator.rewind();
+        animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.progress().abs() <= 1e-5);
+        assert!(animator.tweenable().progress().abs() <= 1e-5);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,10 @@
 //! [`Sprite`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html
 //! [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
 
-use std::time::Duration;
+use std::{
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
 use bevy::{asset::Asset, prelude::*};
 use interpolation::Ease as IEase;
@@ -364,25 +367,13 @@ macro_rules! animator_impl {
             self.tweenable = Box::new(tween);
         }
 
-        /// Get the top-level tweenable this animator is currently controlling.
-        #[must_use]
-        pub fn tweenable(&self) -> &(dyn Tweenable<T> + Send + Sync + 'static) {
-            self.tweenable.as_ref()
-        }
-
-        /// Get the top-level mutable tweenable this animator is currently controlling.
-        #[must_use]
-        pub fn tweenable_mut(&mut self) -> &mut (dyn Tweenable<T> + Send + Sync + 'static) {
-            self.tweenable.as_mut()
-        }
-
         /// Stop animation playback and rewind the animation.
         ///
         /// This changes the animator state to [`AnimatorState::Paused`] and rewind its
         /// tweenable.
         pub fn stop(&mut self) {
             self.state = AnimatorState::Paused;
-            self.tweenable_mut().rewind();
+            self.rewind();
         }
     };
 }
@@ -394,6 +385,20 @@ pub struct Animator<T: Component> {
     pub state: AnimatorState,
     tweenable: BoxedTweenable<T>,
     speed: f32,
+}
+
+impl<T: Component> Deref for Animator<T> {
+    type Target = dyn Tweenable<T> + Send + Sync + 'static;
+
+    fn deref(&self) -> &Self::Target {
+        self.tweenable.as_ref()
+    }
+}
+
+impl<T: Component> DerefMut for Animator<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.tweenable.as_mut()
+    }
 }
 
 impl<T: Component + std::fmt::Debug> std::fmt::Debug for Animator<T> {
@@ -426,6 +431,20 @@ pub struct AssetAnimator<T: Asset> {
     tweenable: BoxedTweenable<T>,
     handle: Handle<T>,
     speed: f32,
+}
+
+impl<T: Asset> Deref for AssetAnimator<T> {
+    type Target = dyn Tweenable<T> + Send + Sync + 'static;
+
+    fn deref(&self) -> &Self::Target {
+        self.tweenable.as_ref()
+    }
+}
+
+impl<T: Asset> DerefMut for AssetAnimator<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.tweenable.as_mut()
+    }
 }
 
 impl<T: Asset + std::fmt::Debug> std::fmt::Debug for AssetAnimator<T> {
@@ -553,8 +572,7 @@ mod tests {
         );
         let animator = Animator::<DummyComponent>::new(tween);
         assert_eq!(animator.state, AnimatorState::default());
-        let tween = animator.tweenable();
-        assert_eq!(tween.progress(), 0.);
+        assert_eq!(animator.progress(), 0.);
     }
 
     #[test]
@@ -579,32 +597,32 @@ mod tests {
         );
         let mut animator = Animator::new(tween);
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
-        animator.tweenable_mut().set_progress(0.5);
+        animator.set_progress(0.5);
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.progress() - 0.5).abs() <= 1e-5);
 
-        animator.tweenable_mut().rewind();
+        animator.rewind();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
-        animator.tweenable_mut().set_progress(0.5);
+        animator.set_progress(0.5);
         animator.state = AnimatorState::Playing;
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.progress() - 0.5).abs() <= 1e-5);
 
-        animator.tweenable_mut().rewind();
+        animator.rewind();
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
     }
 
     #[test]
@@ -617,7 +635,7 @@ mod tests {
         let animator = AssetAnimator::new(Handle::<DummyAsset>::default(), tween);
         assert_eq!(animator.state, AnimatorState::default());
         assert_eq!(animator.handle(), Handle::<DummyAsset>::default());
-        let tween = animator.tweenable();
+        let tween = animator;
         assert_eq!(tween.progress(), 0.);
     }
 
@@ -644,31 +662,31 @@ mod tests {
         );
         let mut animator = AssetAnimator::new(Handle::<DummyAsset>::default(), tween);
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
-        animator.tweenable_mut().set_progress(0.5);
+        animator.set_progress(0.5);
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.progress() - 0.5).abs() <= 1e-5);
 
-        animator.tweenable_mut().rewind();
+        animator.rewind();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
-        animator.tweenable_mut().set_progress(0.5);
+        animator.set_progress(0.5);
         animator.state = AnimatorState::Playing;
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert!((animator.progress() - 0.5).abs() <= 1e-5);
 
-        animator.tweenable_mut().rewind();
+        animator.rewind();
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert!(animator.progress().abs() <= 1e-5);
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -69,9 +69,7 @@ pub fn component_animator_system<T: Component>(
 ) {
     for (entity, ref mut target, ref mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
-            animator
-                .tweenable_mut()
-                .tick(time.delta(), target, entity, &mut event_writer);
+            animator.tick(time.delta(), target, entity, &mut event_writer);
         }
     }
 }
@@ -89,9 +87,7 @@ pub fn asset_animator_system<T: Asset>(
     for (entity, ref mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
             if let Some(target) = assets.get_mut(animator.handle()) {
-                animator
-                    .tweenable_mut()
-                    .tick(time.delta(), target, entity, &mut event_writer);
+                animator.tick(time.delta(), target, entity, &mut event_writer);
             }
         }
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -69,7 +69,9 @@ pub fn component_animator_system<T: Component>(
 ) {
     for (entity, ref mut target, ref mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
-            animator.tick(time.delta(), target, entity, &mut event_writer);
+            animator
+                .tweenable_mut()
+                .tick(time.delta(), target, entity, &mut event_writer);
         }
     }
 }
@@ -87,7 +89,9 @@ pub fn asset_animator_system<T: Asset>(
     for (entity, ref mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
             if let Some(target) = assets.get_mut(animator.handle()) {
-                animator.tick(time.delta(), target, entity, &mut event_writer);
+                animator
+                    .tweenable_mut()
+                    .tick(time.delta(), target, entity, &mut event_writer);
             }
         }
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -75,7 +75,9 @@ pub fn component_animator_system<T: Component>(
 ) {
     for (entity, ref mut target, ref mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
-            animator.tick(time.delta(), target, entity, &mut event_writer);
+            animator
+                .tweenable_mut()
+                .tick(time.delta(), target, entity, &mut event_writer);
         }
     }
 }
@@ -96,7 +98,9 @@ pub fn asset_animator_system<T: Asset>(
     for (entity, ref mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
             if let Some(target) = assets.get_mut(&animator.handle()) {
-                animator.tick(time.delta(), target, entity, &mut event_writer);
+                animator
+                    .tweenable_mut()
+                    .tick(time.delta(), target, entity, &mut event_writer);
             }
         }
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,12 +1,10 @@
+#[cfg(feature = "bevy_asset")]
+use bevy::asset::Asset;
 use bevy::{ecs::component::Component, prelude::*};
 
 #[cfg(feature = "bevy_asset")]
-use bevy::asset::Asset;
-
-use crate::{Animator, AnimatorState, TweenCompleted};
-
-#[cfg(feature = "bevy_asset")]
 use crate::AssetAnimator;
+use crate::{Animator, AnimatorState, TweenCompleted};
 
 /// Plugin to add systems related to tweening of common components and assets.
 ///


### PR DESCRIPTION
Perhaps I'm missing something, but I don't see a use case for having an Animator that doesn't have a tween and therefore does nothing. Getting rid of this option makes the animator API surface significantly simpler.