### PR TITLE
Upgrade to Bevy 0.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,10 @@ jobs:
         run: cargo test --no-default-features --features="bevy_sprite"
         env:
           CARGO_INCREMENTAL: 1
+      - name: Build & run tests (asset)
+        run: cargo test --no-default-features --features="bevy_asset"
+        env:
+          CARGO_INCREMENTAL: 1
       - name: Build & run tests (all)
         run: cargo test --all-features
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `is_forward()` and `is_backward()` convenience helpers to `TweeningDirection`.
-- Added `Tween::set_direction()` and `Tween::with_direction()` which allow configuring the playback direction of a tween, allowing to play it backward from end to start.
-- Added support for dynamically changing an animation's speed with `Animator::set_speed`.
-- Added `AnimationSystem` label to tweening tick systems.
-- Added `BoxedTweenable` type to make working with `Box<dyn Tweenable + ...>` easier.
-- Added `RepeatCount` and `RepeatStrategy` for more granular control over animation looping.
-- Added `with_repeat_count()` and `with_repeat_strategy()` builder methods to `Tween<T>`.
+- Add `is_forward()` and `is_backward()` convenience helpers to `TweeningDirection`.
+- Add `Tween::set_direction()` and `Tween::with_direction()` which allow configuring the playback direction of a tween, allowing to play it backward from end to start.
+- Support dynamically changing an animation's speed with `Animator::set_speed`
+- Add `AnimationSystem` label to tweening tick systems
+- A `BoxedTweenable` type to make working with `Box<dyn Tweenable + ...>` easier
 
 ### Changed
 
-- Double boxing in `Sequence` and `Tracks` was fixed. As a result, any custom tweenables.
+- Double boxing in `Sequence` and `Tracks` was fixed. As a result, any custom tweenables
   should implement `From` for `BoxedTweenable` to make those APIs easier to use.
-- Removed the `tweening_type` parameter from the signature of `Tween<T>::new()`; use `with_repeat_count()` and `with_repeat_strategy()` instead.
-
-### Removed
-
-- Removed `Tweenable::is_looping()`, which was not implemented for most tweenables.
-- Removed `TweeningType` in favor of `RepeatCount` and `RepeatStrategy`.
 
 ## [0.4.0] - 2022-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `is_forward()` and `is_backward()` convenience helpers to `TweeningDirection`.
-- Add `Tween::set_direction()` and `Tween::with_direction()` which allow configuring the playback direction of a tween, allowing to play it backward from end to start.
-- Support dynamically changing an animation's speed with `Animator::set_speed`
-- Add `AnimationSystem` label to tweening tick systems
-- A `BoxedTweenable` type to make working with `Box<dyn Tweenable + ...>` easier
+- Added `is_forward()` and `is_backward()` convenience helpers to `TweeningDirection`.
+- Added `Tween::set_direction()` and `Tween::with_direction()` which allow configuring the playback direction of a tween, allowing to play it backward from end to start.
+- Added support for dynamically changing an animation's speed with `Animator::set_speed`.
+- Added `AnimationSystem` label to tweening tick systems.
+- Added a `BoxedTweenable` trait to make working with `Box<dyn Tweenable + ...>` easier.
 
 ### Changed
 
+- Compatible with Bevy 0.8
 - Double boxing in `Sequence` and `Tracks` was fixed. As a result, any custom tweenables
   should implement `From` for `BoxedTweenable` to make those APIs easier to use.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tweening"
-version = "0.4.0"
+version = "0.5.0-dev"
 authors = ["François Mockers <mockersf@gmail.com>", "Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Tweening animation plugin for the Bevy game engine"
@@ -13,7 +13,9 @@ readme = "README.md"
 exclude = ["examples/*.gif", ".github", "release.md"]
 
 [features]
-default = ["bevy_sprite", "bevy_ui"]
+default = ["bevy_sprite", "bevy_ui", "bevy_asset"]
+# Enable support for Asset animation
+bevy_asset = ["bevy/bevy_asset"]
 # Enable built-in lenses for Bevy sprites
 bevy_sprite = ["bevy/bevy_sprite", "bevy/bevy_render"]
 # Enable built-in lenses for Bevy UI
@@ -21,10 +23,10 @@ bevy_ui = ["bevy/bevy_ui", "bevy/bevy_text", "bevy/bevy_render"]
 
 [dependencies]
 interpolation = "0.2"
-bevy = { version = "0.7", default-features = false }
+bevy = { version = "0.8", default-features = false }
 
 [dev-dependencies]
-bevy-inspector-egui = "0.10"
+bevy-inspector-egui = "0.12"
 
 [[example]]
 name = "menu"
@@ -32,7 +34,7 @@ required-features = [ "bevy/bevy_winit" ]
 
 [[example]]
 name = "colormaterial_color"
-required-features = [ "bevy_sprite", "bevy/bevy_winit" ]
+required-features = [ "bevy_asset", "bevy_sprite", "bevy/bevy_winit" ]
 
 [[example]]
 name = "sprite_color"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crate](https://img.shields.io/crates/v/bevy_tweening.svg)](https://crates.io/crates/bevy_tweening)
 [![Build Status](https://github.com/djeedai/bevy_tweening/actions/workflows/ci.yaml/badge.svg)](https://github.com/djeedai/bevy_tweening/actions/workflows/ci.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/djeedai/bevy_tweening/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/djeedai/bevy_tweening?branch=main)
-[![Bevy tracking](https://img.shields.io/badge/Bevy%20tracking-v0.7-lightblue)](https://github.com/bevyengine/bevy/blob/main/docs/plugins_guidelines.md#main-branch-tracking)
+[![Bevy tracking](https://img.shields.io/badge/Bevy%20tracking-v0.8-lightblue)](https://github.com/bevyengine/bevy/blob/main/docs/plugins_guidelines.md#main-branch-tracking)
 
 Tweening animation plugin for the Bevy game engine.
 
@@ -31,6 +31,7 @@ This crate supports the following features:
 
 | Feature | Default | Description |
 |---|---|---|
+| `bevy_asset`  | Yes | Enable animating Bevy assets (`Asset`) in addition of components. |
 | `bevy_sprite` | Yes | Includes built-in lenses for some `Sprite`-related components. |
 | `bevy_ui`     | Yes | Includes built-in lenses for some UI-related components. |
 
@@ -63,7 +64,7 @@ let tween = Tween::new(
     // to animate it. It also contains the start and end values associated
     // with the animation ratios 0. and 1.
     TransformPositionLens {
-        start: Vec3::new(0., 0., 0.),
+        start: Vec3::ZERO,
         end: Vec3::new(1., 2., -4.),
     },
 );
@@ -111,16 +112,16 @@ The naming scheme for predefined lenses is `"<TargetName><FieldName>Lens"`, wher
 
 | Target Component | Animated Field | Lens | Feature |
 |---|---|---|---|
-| [`Transform`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html) | [`translation`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.translation) | [`TransformPositionLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformPositionLens.html) | |
-| | [`rotation`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (`Quat`)¹ | [`TransformRotationLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotationLens.html) | |
-| | [`rotation`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateXLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateXLens.html) | |
-| | [`rotation`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateYLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateYLens.html) | |
-| | [`rotation`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateZLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateZLens.html) | |
-| | [`rotation`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateAxisLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateAxisLens.html) | |
-| | [`scale`](https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.scale) | [`TransformScaleLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformScaleLens.html) | |
-| [`Sprite`](https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html) | [`color`](https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html#structfield.color) | [`SpriteColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.SpriteColorLens.html) | `bevy_sprite` |
-| [`Style`](https://docs.rs/bevy/0.7.0/bevy/ui/struct.Style.html) | [`position`](https://docs.rs/bevy/0.7.0/bevy/ui/struct.Style.html#structfield.position) | [`UiPositionLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.UiPositionLens.html) | `bevy_ui` |
-| [`Text`](https://docs.rs/bevy/0.7.0/bevy/text/struct.Text.html) | [`TextStyle::color`](https://docs.rs/bevy/0.7.0/bevy/text/struct.TextStyle.html#structfield.color) | [`TextColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TextColorLens.html) | `bevy_ui` |
+| [`Transform`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html) | [`translation`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.translation) | [`TransformPositionLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformPositionLens.html) | |
+| | [`rotation`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (`Quat`)¹ | [`TransformRotationLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotationLens.html) | |
+| | [`rotation`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateXLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateXLens.html) | |
+| | [`rotation`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateYLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateYLens.html) | |
+| | [`rotation`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateZLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateZLens.html) | |
+| | [`rotation`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.rotation) (angle)² | [`TransformRotateAxisLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformRotateAxisLens.html) | |
+| | [`scale`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.scale) | [`TransformScaleLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformScaleLens.html) | |
+| [`Sprite`](https://docs.rs/bevy/0.8.0/bevy/sprite/struct.Sprite.html) | [`color`](https://docs.rs/bevy/0.8.0/bevy/sprite/struct.Sprite.html#structfield.color) | [`SpriteColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.SpriteColorLens.html) | `bevy_sprite` |
+| [`Style`](https://docs.rs/bevy/0.8.0/bevy/ui/struct.Style.html) | [`position`](https://docs.rs/bevy/0.8.0/bevy/ui/struct.Style.html#structfield.position) | [`UiPositionLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.UiPositionLens.html) | `bevy_ui` |
+| [`Text`](https://docs.rs/bevy/0.8.0/bevy/text/struct.Text.html) | [`TextStyle::color`](https://docs.rs/bevy/0.8.0/bevy/text/struct.TextStyle.html#structfield.color) | [`TextColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TextColorLens.html) | `bevy_ui` |
 
 ¹ Shortest-path interpolation between two rotations, using `Quat::slerp()`.
 
@@ -130,9 +131,11 @@ See the [comparison of rotation lenses](https://docs.rs/bevy_tweening/0.4.0/bevy
 
 ### Bevy Assets
 
+Asset animation always requires the `bevy_asset` feature.
+
 | Target Asset | Animated Field | Lens | Feature |
 |---|---|---|---|
-| [`ColorMaterial`](https://docs.rs/bevy/0.7.0/bevy/sprite/struct.ColorMaterial.html) | [`color`](https://docs.rs/bevy/0.7.0/bevy/sprite/struct.ColorMaterial.html#structfield.color) | [`ColorMaterialColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.ColorMaterialColorLens.html) | `bevy_sprite` |
+| [`ColorMaterial`](https://docs.rs/bevy/0.8.0/bevy/sprite/struct.ColorMaterial.html) | [`color`](https://docs.rs/bevy/0.8.0/bevy/sprite/struct.ColorMaterial.html#structfield.color) | [`ColorMaterialColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.ColorMaterialColorLens.html) | `bevy_asset` + `bevy_sprite` |
 
 ## Custom lens
 
@@ -186,7 +189,7 @@ Then, in addition, the system `component_animator_system::<CustomComponent>` nee
 
 ## Custom asset support
 
-The process is similar to custom components, creating a custom lens for the custom asset. The system to add is `asset_animator_system::<CustomAsset>`.
+The process is similar to custom components, creating a custom lens for the custom asset. The system to add is `asset_animator_system::<CustomAsset>`. This requires the `bevy_asset` feature (enabled by default).
 
 ## Examples
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@ criterion = { version = "0.3", features = ["html_reports"] }
 bevy_tweening = { path = "../" }
 
 [dependencies.bevy]
-version = "0.6"
+version = "0.8.0"
 default-features = false
 features = [ "render" ]
 

--- a/benchmarks/benches/lens.rs
+++ b/benchmarks/benches/lens.rs
@@ -11,18 +11,18 @@ fn text_color_lens(c: &mut Criterion) {
         end: Color::BLUE,
         section: 0,
     };
-    let mut text = Text::with_section(
+    let mut text = Text::from_section(
         "test".to_string(),
         TextStyle {
             font: Default::default(),
             font_size: 60.0,
             color: Color::WHITE,
         },
-        TextAlignment {
-            vertical: VerticalAlign::Center,
-            horizontal: HorizontalAlign::Center,
-        },
-    );
+    )
+    .with_alignment(TextAlignment {
+        vertical: VerticalAlign::Center,
+        horizontal: HorizontalAlign::Center,
+    });
     c.bench_function("TextColorLens", |b| {
         b.iter(|| lens.lerp(&mut text, black_box(0.3)))
     });

--- a/examples/colormaterial_color.rs
+++ b/examples/colormaterial_color.rs
@@ -77,14 +77,13 @@ fn setup(
 
         let tween = Tween::new(
             *ease_function,
+            TweeningType::PingPong,
             Duration::from_secs(1),
             ColorMaterialColorLens {
                 start: Color::RED,
                 end: Color::BLUE,
             },
-        )
-        .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+        );
 
         commands
             .spawn_bundle(MaterialMesh2dBundle {

--- a/examples/colormaterial_color.rs
+++ b/examples/colormaterial_color.rs
@@ -25,7 +25,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let size = 80.;
 

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -20,17 +20,17 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let font = asset_server.load("fonts/FiraMono-Regular.ttf");
 
-    let container = commands
+    commands
         .spawn_bundle(NodeBundle {
             style: Style {
                 position_type: PositionType::Absolute,
-                position: Rect::all(Val::Px(0.)),
-                margin: Rect::all(Val::Px(16.)),
-                padding: Rect::all(Val::Px(16.)),
+                position: UiRect::all(Val::Px(0.)),
+                margin: UiRect::all(Val::Px(16.)),
+                padding: UiRect::all(Val::Px(16.)),
                 flex_direction: FlexDirection::ColumnReverse,
                 align_content: AlignContent::Center,
                 align_items: AlignItems::Center,
@@ -42,60 +42,59 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             ..default()
         })
         .insert(Name::new("menu"))
-        .id();
-
-    let mut start_time_ms = 0;
-    for text in &["Continue", "New Game", "Settings", "Quit"] {
-        let delay = Delay::new(Duration::from_millis(start_time_ms));
-        start_time_ms += 500;
-        let tween_scale = Tween::new(
-            EaseFunction::BounceOut,
-            TweeningType::Once,
-            Duration::from_secs(2),
-            TransformScaleLens {
-                start: Vec3::splat(0.01),
-                end: Vec3::ONE,
-            },
-        );
-        let seq = delay.then(tween_scale);
-        commands
-            .spawn_bundle(NodeBundle {
-                node: Node {
-                    size: Vec2::new(300., 80.),
-                },
-                style: Style {
-                    min_size: Size::new(Val::Px(300.), Val::Px(80.)),
-                    margin: Rect::all(Val::Px(8.)),
-                    padding: Rect::all(Val::Px(8.)),
-                    align_content: AlignContent::Center,
-                    align_items: AlignItems::Center,
-                    align_self: AlignSelf::Center,
-                    justify_content: JustifyContent::Center,
-                    ..default()
-                },
-                color: UiColor(Color::rgb_u8(162, 226, 95)),
-                transform: Transform::from_scale(Vec3::splat(0.01)),
-                ..default()
-            })
-            .insert(Name::new(format!("button:{}", text)))
-            .insert(Parent(container))
-            .insert(Animator::new(seq))
-            .with_children(|parent| {
-                parent.spawn_bundle(TextBundle {
-                    text: Text::with_section(
-                        text.to_string(),
-                        TextStyle {
-                            font: font.clone(),
-                            font_size: 48.0,
-                            color: Color::rgb_u8(83, 163, 130),
+        .with_children(|container| {
+            let mut start_time_ms = 0;
+            for text in &["Continue", "New Game", "Settings", "Quit"] {
+                let delay = Delay::new(Duration::from_millis(start_time_ms));
+                start_time_ms += 500;
+                let tween_scale = Tween::new(
+                    EaseFunction::BounceOut,
+                    TweeningType::Once,
+                    Duration::from_secs(2),
+                    TransformScaleLens {
+                        start: Vec3::splat(0.01),
+                        end: Vec3::ONE,
+                    },
+                );
+                let seq = delay.then(tween_scale);
+                container
+                    .spawn_bundle(NodeBundle {
+                        node: Node {
+                            size: Vec2::new(300., 80.),
                         },
-                        TextAlignment {
-                            vertical: VerticalAlign::Center,
-                            horizontal: HorizontalAlign::Center,
+                        style: Style {
+                            min_size: Size::new(Val::Px(300.), Val::Px(80.)),
+                            margin: UiRect::all(Val::Px(8.)),
+                            padding: UiRect::all(Val::Px(8.)),
+                            align_content: AlignContent::Center,
+                            align_items: AlignItems::Center,
+                            align_self: AlignSelf::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
                         },
-                    ),
-                    ..default()
-                });
-            });
-    }
+                        color: UiColor(Color::rgb_u8(162, 226, 95)),
+                        transform: Transform::from_scale(Vec3::splat(0.01)),
+                        ..default()
+                    })
+                    .insert(Name::new(format!("button:{}", text)))
+                    .insert(Animator::new(seq))
+                    .with_children(|parent| {
+                        parent.spawn_bundle(TextBundle {
+                            text: Text::from_section(
+                                text.to_string(),
+                                TextStyle {
+                                    font: font.clone(),
+                                    font_size: 48.0,
+                                    color: Color::rgb_u8(83, 163, 130),
+                                },
+                            )
+                            .with_alignment(TextAlignment {
+                                vertical: VerticalAlign::Center,
+                                horizontal: HorizontalAlign::Center,
+                            }),
+                            ..default()
+                        });
+                    });
+            }
+        });
 }

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -50,6 +50,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         start_time_ms += 500;
         let tween_scale = Tween::new(
             EaseFunction::BounceOut,
+            TweeningType::Once,
             Duration::from_secs(2),
             TransformScaleLens {
                 start: Vec3::splat(0.01),

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -31,7 +31,7 @@ struct RedSprite;
 struct BlueSprite;
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let font = asset_server.load("fonts/FiraMono-Regular.ttf");
     let text_style_red = TextStyle {

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -1,8 +1,6 @@
-use std::time::Duration;
-
 use bevy::prelude::*;
-
 use bevy_tweening::{lens::*, *};
+use std::time::Duration;
 
 fn main() {
     App::default()
@@ -109,31 +107,19 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Vec3::new(margin, screen_y - margin, 0.),
         Vec3::new(margin, margin, 0.),
     ];
-    // Build a sequence from an iterator over a Tweenable (here, a
-    // Tracks<Transform>)
+    // Build a sequence from an iterator over a Tweenable (here, a Tween<Transform>)
     let seq = Sequence::new(dests.windows(2).enumerate().map(|(index, pair)| {
-        Tracks::new([
-            Tween::new(
-                EaseFunction::QuadraticInOut,
-                Duration::from_millis(250),
-                TransformRotateZLens {
-                    start: 0.,
-                    end: 180_f32.to_radians(),
-                },
-            )
-            .with_repeat_count(RepeatCount::Finite(4))
-            .with_repeat_strategy(RepeatStrategy::MirroredRepeat),
-            Tween::new(
-                EaseFunction::QuadraticInOut,
-                Duration::from_secs(1),
-                TransformPositionLens {
-                    start: pair[0] - center,
-                    end: pair[1] - center,
-                },
-            )
-            // Get an event after each segment
-            .with_completed_event(index as u64),
-        ])
+        Tween::new(
+            EaseFunction::QuadraticInOut,
+            TweeningType::Once,
+            Duration::from_secs(1),
+            TransformPositionLens {
+                start: pair[0] - center,
+                end: pair[1] - center,
+            },
+        )
+        // Get an event after each segment
+        .with_completed_event(index as u64)
     }));
 
     commands
@@ -152,6 +138,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // scaling size at the same time.
     let tween_move = Tween::new(
         EaseFunction::QuadraticInOut,
+        TweeningType::Once,
         Duration::from_secs(1),
         TransformPositionLens {
             start: Vec3::new(-200., 100., 0.),
@@ -161,6 +148,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     .with_completed_event(99); // Get an event once move completed
     let tween_rotate = Tween::new(
         EaseFunction::QuadraticInOut,
+        TweeningType::Once,
         Duration::from_secs(1),
         TransformRotationLens {
             start: Quat::IDENTITY,
@@ -169,6 +157,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     );
     let tween_scale = Tween::new(
         EaseFunction::QuadraticInOut,
+        TweeningType::Once,
         Duration::from_secs(1),
         TransformScaleLens {
             start: Vec3::ONE,

--- a/examples/sprite_color.rs
+++ b/examples/sprite_color.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let size = 80.;
 

--- a/examples/sprite_color.rs
+++ b/examples/sprite_color.rs
@@ -61,14 +61,13 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
+            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             SpriteColorLens {
                 start: Color::RED,
                 end: Color::BLUE,
             },
-        )
-        .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+        );
 
         commands
             .spawn_bundle(SpriteBundle {

--- a/examples/text_color.rs
+++ b/examples/text_color.rs
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let font = asset_server.load("fonts/FiraMono-Regular.ttf");
 
@@ -81,7 +81,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             .spawn_bundle(TextBundle {
                 style: Style {
                     size: Size::new(Val::Px(size_x), Val::Px(size_y)),
-                    position: Rect {
+                    position: UiRect {
                         left: Val::Px(x),
                         top: Val::Px(y),
                         right: Val::Auto,
@@ -94,15 +94,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     justify_content: JustifyContent::Center,
                     ..default()
                 },
-                text: Text::with_section(
+                text: Text::from_section(
                     *ease_name,
                     TextStyle {
                         font: font.clone(),
                         font_size: 24.0,
                         color: Color::WHITE,
                     },
-                    // you can still use Default
-                    default(),
                 ),
                 ..default()
             })

--- a/examples/text_color.rs
+++ b/examples/text_color.rs
@@ -68,15 +68,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ] {
         let tween = Tween::new(
             *ease_function,
+            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             TextColorLens {
                 start: Color::RED,
                 end: Color::BLUE,
                 section: 0,
             },
-        )
-        .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+        );
 
         commands
             .spawn_bundle(TextBundle {

--- a/examples/transform_rotation.rs
+++ b/examples/transform_rotation.rs
@@ -77,14 +77,13 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
+            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             TransformRotationLens {
                 start: Quat::IDENTITY,
                 end: Quat::from_axis_angle(Vec3::Z, std::f32::consts::PI / 2.),
             },
-        )
-        .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+        );
 
         commands
             .spawn_bundle((

--- a/examples/transform_rotation.rs
+++ b/examples/transform_rotation.rs
@@ -33,7 +33,7 @@ impl Default for Options {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let size = 80.;
 
@@ -86,10 +86,10 @@ fn setup(mut commands: Commands) {
         );
 
         commands
-            .spawn_bundle((
-                Transform::from_translation(Vec3::new(x, y, 0.)),
-                GlobalTransform::default(),
-            ))
+            .spawn_bundle(SpatialBundle {
+                transform: Transform::from_translation(Vec3::new(x, y, 0.)),
+                ..default()
+            })
             .with_children(|parent| {
                 parent
                     .spawn_bundle(SpriteBundle {

--- a/examples/transform_translation.rs
+++ b/examples/transform_translation.rs
@@ -33,7 +33,7 @@ impl Default for Options {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn_bundle(OrthographicCameraBundle::new_2d());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let size = 25.;
 

--- a/examples/transform_translation.rs
+++ b/examples/transform_translation.rs
@@ -76,14 +76,13 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
+            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             TransformPositionLens {
                 start: Vec3::new(x, screen_y, 0.),
                 end: Vec3::new(x, -screen_y, 0.),
             },
-        )
-        .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+        );
 
         commands
             .spawn_bundle(SpriteBundle {

--- a/examples/ui_position.rs
+++ b/examples/ui_position.rs
@@ -76,6 +76,7 @@ fn setup(mut commands: Commands) {
     ] {
         let tween = Tween::new(
             *ease_function,
+            TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             UiPositionLens {
                 start: Rect {
@@ -91,9 +92,7 @@ fn setup(mut commands: Commands) {
                     bottom: Val::Auto,
                 },
             },
-        )
-        .with_repeat_count(RepeatCount::Infinite)
-        .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+        );
 
         commands
             .spawn_bundle(NodeBundle {

--- a/examples/ui_position.rs
+++ b/examples/ui_position.rs
@@ -33,7 +33,7 @@ impl Default for Options {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn_bundle(UiCameraBundle::default());
+    commands.spawn_bundle(Camera2dBundle::default());
 
     let size = 25.;
 
@@ -79,13 +79,13 @@ fn setup(mut commands: Commands) {
             TweeningType::PingPong,
             std::time::Duration::from_secs(1),
             UiPositionLens {
-                start: Rect {
+                start: UiRect {
                     left: Val::Px(x),
                     top: Val::Px(10.),
                     right: Val::Auto,
                     bottom: Val::Auto,
                 },
-                end: Rect {
+                end: UiRect {
                     left: Val::Px(x),
                     top: Val::Px(screen_y - 10. - size),
                     right: Val::Auto,
@@ -98,7 +98,7 @@ fn setup(mut commands: Commands) {
             .spawn_bundle(NodeBundle {
                 style: Style {
                     size: Size::new(Val::Px(size), Val::Px(size)),
-                    position: Rect {
+                    position: UiRect {
                         left: Val::Px(x),
                         top: Val::Px(10.),
                         right: Val::Auto,

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -31,9 +31,9 @@
 //! - [`TransformRotateZLens`]
 //! - [`TransformRotateAxisLens`]
 //!
-//! [`rotation`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.rotation
-//! [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
-//! [`Quat::slerp()`]: https://docs.rs/bevy/0.7.0/bevy/math/struct.Quat.html#method.slerp
+//! [`rotation`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.rotation
+//! [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
+//! [`Quat::slerp()`]: https://docs.rs/bevy/0.8.0/bevy/math/struct.Quat.html#method.slerp
 
 use bevy::prelude::*;
 
@@ -77,8 +77,8 @@ pub trait Lens<T> {
 /// A lens to manipulate the [`color`] field of a section of a [`Text`]
 /// component.
 ///
-/// [`color`]: https://docs.rs/bevy/0.7.0/bevy/text/struct.TextStyle.html#structfield.color
-/// [`Text`]: https://docs.rs/bevy/0.7.0/bevy/text/struct.Text.html
+/// [`color`]: https://docs.rs/bevy/0.8.0/bevy/text/struct.TextStyle.html#structfield.color
+/// [`Text`]: https://docs.rs/bevy/0.8.0/bevy/text/struct.Text.html
 #[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TextColorLens {
@@ -104,8 +104,8 @@ impl Lens<Text> for TextColorLens {
 
 /// A lens to manipulate the [`translation`] field of a [`Transform`] component.
 ///
-/// [`translation`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.translation
-/// [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
+/// [`translation`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.translation
+/// [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformPositionLens {
     /// Start value of the translation.
@@ -134,9 +134,9 @@ impl Lens<Transform> for TransformPositionLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`rotation`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.rotation
-/// [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
-/// [`Quat::slerp()`]: https://docs.rs/bevy/0.7.0/bevy/math/struct.Quat.html#method.slerp
+/// [`rotation`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.rotation
+/// [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
+/// [`Quat::slerp()`]: https://docs.rs/bevy/0.8.0/bevy/math/struct.Quat.html#method.slerp
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotationLens {
@@ -162,7 +162,7 @@ impl Lens<Transform> for TransformRotationLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateXLens {
@@ -189,7 +189,7 @@ impl Lens<Transform> for TransformRotateXLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateYLens {
@@ -216,7 +216,7 @@ impl Lens<Transform> for TransformRotateYLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateZLens {
@@ -247,7 +247,7 @@ impl Lens<Transform> for TransformRotateZLens {
 ///
 /// This method panics if the `axis` vector is not normalized.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateAxisLens {
@@ -268,8 +268,8 @@ impl Lens<Transform> for TransformRotateAxisLens {
 
 /// A lens to manipulate the [`scale`] field of a [`Transform`] component.
 ///
-/// [`scale`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.scale
-/// [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
+/// [`scale`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.scale
+/// [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformScaleLens {
     /// Start value of the scale.
@@ -287,15 +287,15 @@ impl Lens<Transform> for TransformScaleLens {
 
 /// A lens to manipulate the [`position`] field of a UI [`Style`] component.
 ///
-/// [`position`]: https://docs.rs/bevy/0.7.0/bevy/ui/struct.Style.html#structfield.position
-/// [`Style`]: https://docs.rs/bevy/0.7.0/bevy/ui/struct.Style.html
+/// [`position`]: https://docs.rs/bevy/0.8.0/bevy/ui/struct.Style.html#structfield.position
+/// [`Style`]: https://docs.rs/bevy/0.8.0/bevy/ui/struct.Style.html
 #[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiPositionLens {
     /// Start position.
-    pub start: Rect<Val>,
+    pub start: UiRect<Val>,
     /// End position.
-    pub end: Rect<Val>,
+    pub end: UiRect<Val>,
 }
 
 #[cfg(feature = "bevy_ui")]
@@ -312,7 +312,7 @@ fn lerp_val(start: &Val, end: &Val, ratio: f32) -> Val {
 #[cfg(feature = "bevy_ui")]
 impl Lens<Style> for UiPositionLens {
     fn lerp(&mut self, target: &mut Style, ratio: f32) {
-        target.position = Rect {
+        target.position = UiRect {
             left: lerp_val(&self.start.left, &self.end.left, ratio),
             right: lerp_val(&self.start.right, &self.end.right, ratio),
             top: lerp_val(&self.start.top, &self.end.top, ratio),
@@ -323,8 +323,8 @@ impl Lens<Style> for UiPositionLens {
 
 /// A lens to manipulate the [`color`] field of a [`ColorMaterial`] asset.
 ///
-/// [`color`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.ColorMaterial.html#structfield.color
-/// [`ColorMaterial`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.ColorMaterial.html
+/// [`color`]: https://docs.rs/bevy/0.8.0/bevy/sprite/struct.ColorMaterial.html#structfield.color
+/// [`ColorMaterial`]: https://docs.rs/bevy/0.8.0/bevy/sprite/struct.ColorMaterial.html
 #[cfg(feature = "bevy_sprite")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ColorMaterialColorLens {
@@ -348,8 +348,8 @@ impl Lens<ColorMaterial> for ColorMaterialColorLens {
 
 /// A lens to manipulate the [`color`] field of a [`Sprite`] asset.
 ///
-/// [`color`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html#structfield.color
-/// [`Sprite`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html
+/// [`color`]: https://docs.rs/bevy/0.8.0/bevy/sprite/struct.Sprite.html#structfield.color
+/// [`Sprite`]: https://docs.rs/bevy/0.8.0/bevy/sprite/struct.Sprite.html
 #[cfg(feature = "bevy_sprite")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct SpriteColorLens {
@@ -384,7 +384,7 @@ mod tests {
             end: Color::BLUE,
             section: 0,
         };
-        let mut text = Text::with_section("", default(), default());
+        let mut text = Text::from_section("", default());
 
         lens.lerp(&mut text, 0.);
         assert_eq!(text.sections[0].style.color, Color::RED);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,10 @@
 //! let tween = Tween::new(
 //!     // Use a quadratic easing on both endpoints.
 //!     EaseFunction::QuadraticInOut,
-//!     // Animation time.
+//!     // Loop animation back and forth.
+//!     TweeningType::PingPong,
+//!     // Animation time (one way only; for ping-pong it takes 2 seconds
+//!     // to come back to start).
 //!     Duration::from_secs(1),
 //!     // The lens gives access to the Transform component of the Entity,
 //!     // for the Animator to animate it. It also contains the start and
@@ -87,6 +90,7 @@
 //! let tween1 = Tween::new(
 //!     // [...]
 //! #    EaseFunction::BounceOut,
+//! #    TweeningType::Once,
 //! #    Duration::from_secs(2),
 //! #    TransformScaleLens {
 //! #        start: Vec3::ZERO,
@@ -96,6 +100,7 @@
 //! let tween2 = Tween::new(
 //!     // [...]
 //! #    EaseFunction::QuadraticInOut,
+//! #    TweeningType::Once,
 //! #    Duration::from_secs(1),
 //! #    TransformPositionLens {
 //! #        start: Vec3::ZERO,
@@ -151,11 +156,15 @@
 //! [`Sprite`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html
 //! [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
 
+use bevy::{asset::Asset, prelude::*};
 use std::time::Duration;
 
-use bevy::{asset::Asset, prelude::*};
 use interpolation::Ease as IEase;
 pub use interpolation::{EaseFunction, Lerp};
+
+pub mod lens;
+mod plugin;
+mod tweenable;
 
 pub use lens::Lens;
 pub use plugin::{
@@ -165,47 +174,24 @@ pub use tweenable::{
     BoxedTweenable, Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState, Tweenable,
 };
 
-pub mod lens;
-mod plugin;
-mod tweenable;
-
-/// How many times to repeat a tween animation. See also: [`RepeatStrategy`].
+/// Type of looping for a tween animation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RepeatCount {
-    /// Run the animation N times.
-    Finite(u32),
-    /// Run the animation for some amount of time.
-    For(Duration),
-    /// Loop the animation indefinitely.
-    Infinite,
+pub enum TweeningType {
+    /// Run the animation once from start to end only.
+    Once,
+    /// Loop the animation indefinitely, restarting from the start each time the
+    /// end is reached.
+    Loop,
+    /// Loop the animation back and forth, changing direction each time an
+    /// endpoint is reached. A complete cycle start -> end -> start always
+    /// counts as 2 loop iterations for the various operations where looping
+    /// matters.
+    PingPong,
 }
 
-/// What to do when a tween animation needs to be repeated.
-///
-/// Only applicable when [`RepeatCount`] is greater than the animation duration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RepeatStrategy {
-    /// Reset the animation back to its starting position.
-    Repeat,
-    /// Follow a ping-pong pattern, changing the direction each time an endpoint
-    /// is reached.
-    ///
-    /// A complete cycle start -> end -> start always counts as 2 loop
-    /// iterations for the various operations where looping matters. That
-    /// is, a 1 second animation will take 2 seconds to end up back where it
-    /// started.
-    MirroredRepeat,
-}
-
-impl Default for RepeatCount {
+impl Default for TweeningType {
     fn default() -> Self {
-        Self::Finite(1)
-    }
-}
-
-impl Default for RepeatStrategy {
-    fn default() -> Self {
-        Self::Repeat
+        Self::Once
     }
 }
 
@@ -289,12 +275,12 @@ impl From<EaseFunction> for EaseMethod {
 /// that target at the start bound of the lens, effectively making the animation
 /// play backward.
 ///
-/// For all but [`RepeatStrategy::MirroredRepeat`] this is always
+/// For all but [`TweeningType::PingPong`] this is always
 /// [`TweeningDirection::Forward`], unless manually configured with
-/// [`Tween::set_direction()`] in which case the value is constant equal to the
-/// value set. When using [`RepeatStrategy::MirroredRepeat`], this is either
-/// forward (from start to end; ping) or backward (from end to start; pong),
-/// depending on the current iteration of the loop.
+/// [`Tween::set_direction()`] in which case the value is constant equal
+/// to the value set. For the [`TweeningType::PingPong`] tweening type, this is
+/// either forward (from start to end; ping) or backward (from end to start;
+/// pong), depending on the current iteration of the loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TweeningDirection {
     /// Animation playing from start to end.
@@ -395,8 +381,19 @@ macro_rules! animator_impl {
             }
         }
 
-        /// Get the current progress of the tweenable. See [`Tweenable::progress`] for
-        /// details.
+        /// Get the current progress in \[0:1\] (non-looping) or \[0:1\[ (looping) of
+        /// the animation.
+        ///
+        /// For looping animations, this reports the progress of the current iteration,
+        /// in the current direction:
+        /// - [`TweeningType::Loop`] is 0 at start and 1 at end. The exact value 1.0 is
+        ///   never reached, since the tweenable loops over to 0.0 immediately.
+        /// - [`TweeningType::PingPong`] is 0 at the source endpoint and 1 and the
+        ///   destination one, which are respectively the start/end for
+        ///   [`TweeningDirection::Forward`], or the end/start for
+        ///   [`TweeningDirection::Backward`]. The exact value 1.0 is never reached,
+        ///   since the tweenable loops over to 0.0 immediately when it changes
+        ///   direction at either endpoint.
         ///
         /// For sequences, the progress is measured over the entire sequence, from 0 at
         /// the start of the first child tweenable to 1 at the end of the last one.
@@ -538,9 +535,8 @@ impl<T: Asset> AssetAnimator<T> {
 
 #[cfg(test)]
 mod tests {
-    use bevy::reflect::TypeUuid;
-
     use super::{lens::*, *};
+    use bevy::reflect::TypeUuid;
 
     struct DummyLens {
         start: f32,
@@ -571,15 +567,9 @@ mod tests {
     }
 
     #[test]
-    fn repeat_count() {
-        let count = RepeatCount::default();
-        assert_eq!(count, RepeatCount::Finite(1));
-    }
-
-    #[test]
-    fn repeat_strategy() {
-        let strategy = RepeatStrategy::default();
-        assert_eq!(strategy, RepeatStrategy::Repeat);
+    fn tweening_type() {
+        let tweening_type = TweeningType::default();
+        assert_eq!(tweening_type, TweeningType::Once);
     }
 
     #[test]
@@ -629,6 +619,7 @@ mod tests {
     fn animator_new() {
         let tween = Tween::new(
             EaseFunction::QuadraticInOut,
+            TweeningType::PingPong,
             Duration::from_secs(1),
             DummyLens { start: 0., end: 1. },
         );
@@ -644,6 +635,7 @@ mod tests {
         for state in [AnimatorState::Playing, AnimatorState::Paused] {
             let tween = Tween::<DummyComponent>::new(
                 EaseFunction::QuadraticInOut,
+                TweeningType::PingPong,
                 Duration::from_secs(1),
                 DummyLens { start: 0., end: 1. },
             );
@@ -661,6 +653,7 @@ mod tests {
 
         let tween = Tween::<DummyComponent>::new(
             EaseFunction::QuadraticInOut,
+            TweeningType::PingPong,
             Duration::from_secs(1),
             DummyLens { start: 0., end: 1. },
         );
@@ -674,6 +667,7 @@ mod tests {
     fn animator_controls() {
         let tween = Tween::<DummyComponent>::new(
             EaseFunction::QuadraticInOut,
+            TweeningType::PingPong,
             Duration::from_secs(1),
             DummyLens { start: 0., end: 1. },
         );
@@ -712,6 +706,7 @@ mod tests {
     fn asset_animator_new() {
         let tween = Tween::<DummyAsset>::new(
             EaseFunction::QuadraticInOut,
+            TweeningType::PingPong,
             Duration::from_secs(1),
             DummyLens { start: 0., end: 1. },
         );
@@ -727,6 +722,7 @@ mod tests {
         for state in [AnimatorState::Playing, AnimatorState::Paused] {
             let tween = Tween::<DummyAsset>::new(
                 EaseFunction::QuadraticInOut,
+                TweeningType::PingPong,
                 Duration::from_secs(1),
                 DummyLens { start: 0., end: 1. },
             );
@@ -746,6 +742,7 @@ mod tests {
 
         let tween = Tween::new(
             EaseFunction::QuadraticInOut,
+            TweeningType::PingPong,
             Duration::from_secs(1),
             DummyLens { start: 0., end: 1. },
         );
@@ -760,6 +757,7 @@ mod tests {
     fn asset_animator_controls() {
         let tween = Tween::new(
             EaseFunction::QuadraticInOut,
+            TweeningType::PingPong,
             Duration::from_secs(1),
             DummyLens { start: 0., end: 1. },
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //! ## Assets animation
 //!
 //! Assets are animated in a similar way to component, via the [`AssetAnimator`]
-//! component.
+//! component. This requires the `bevy_asset` feature (enabled by default).
 //!
 //! Because assets are typically shared, and the animation applies to the asset
 //! itself, all users of the asset see the animation. For example, animating the
@@ -149,15 +149,18 @@
 //! lens can also be created by implementing the trait, allowing to animate
 //! virtually any field of any Bevy component or asset.
 //!
-//! [`Transform::translation`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html#structfield.translation
-//! [`Entity`]: https://docs.rs/bevy/0.7.0/bevy/ecs/entity/struct.Entity.html
-//! [`Query`]: https://docs.rs/bevy/0.7.0/bevy/ecs/system/struct.Query.html
-//! [`ColorMaterial`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.ColorMaterial.html
-//! [`Sprite`]: https://docs.rs/bevy/0.7.0/bevy/sprite/struct.Sprite.html
-//! [`Transform`]: https://docs.rs/bevy/0.7.0/bevy/transform/components/struct.Transform.html
+//! [`Transform::translation`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.translation
+//! [`Entity`]: https://docs.rs/bevy/0.8.0/bevy/ecs/entity/struct.Entity.html
+//! [`Query`]: https://docs.rs/bevy/0.8.0/bevy/ecs/system/struct.Query.html
+//! [`ColorMaterial`]: https://docs.rs/bevy/0.8.0/bevy/sprite/struct.ColorMaterial.html
+//! [`Sprite`]: https://docs.rs/bevy/0.8.0/bevy/sprite/struct.Sprite.html
+//! [`Transform`]: https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html
 
-use bevy::{asset::Asset, prelude::*};
+use bevy::prelude::*;
 use std::time::Duration;
+
+#[cfg(feature = "bevy_asset")]
+use bevy::asset::Asset;
 
 use interpolation::Ease as IEase;
 pub use interpolation::{EaseFunction, Lerp};
@@ -167,12 +170,13 @@ mod plugin;
 mod tweenable;
 
 pub use lens::Lens;
-pub use plugin::{
-    asset_animator_system, component_animator_system, AnimationSystem, TweeningPlugin,
-};
+pub use plugin::{component_animator_system, AnimationSystem, TweeningPlugin};
 pub use tweenable::{
     BoxedTweenable, Delay, Sequence, Tracks, Tween, TweenCompleted, TweenState, Tweenable,
 };
+
+#[cfg(feature = "bevy_asset")]
+pub use plugin::asset_animator_system;
 
 /// Type of looping for a tween animation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -486,6 +490,7 @@ impl<T: Component> Animator<T> {
 }
 
 /// Component to control the animation of an asset.
+#[cfg(feature = "bevy_asset")]
 #[derive(Component)]
 pub struct AssetAnimator<T: Asset> {
     /// Control if this animation is played or not.
@@ -495,6 +500,7 @@ pub struct AssetAnimator<T: Asset> {
     speed: f32,
 }
 
+#[cfg(feature = "bevy_asset")]
 impl<T: Asset + std::fmt::Debug> std::fmt::Debug for AssetAnimator<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AssetAnimator")
@@ -503,6 +509,7 @@ impl<T: Asset + std::fmt::Debug> std::fmt::Debug for AssetAnimator<T> {
     }
 }
 
+#[cfg(feature = "bevy_asset")]
 impl<T: Asset> Default for AssetAnimator<T> {
     fn default() -> Self {
         Self {
@@ -514,6 +521,7 @@ impl<T: Asset> Default for AssetAnimator<T> {
     }
 }
 
+#[cfg(feature = "bevy_asset")]
 impl<T: Asset> AssetAnimator<T> {
     /// Create a new asset animator component from a single tweenable.
     #[must_use]
@@ -536,6 +544,8 @@ impl<T: Asset> AssetAnimator<T> {
 #[cfg(test)]
 mod tests {
     use super::{lens::*, *};
+
+    #[cfg(feature = "bevy_asset")]
     use bevy::reflect::TypeUuid;
 
     struct DummyLens {
@@ -548,6 +558,7 @@ mod tests {
         value: f32,
     }
 
+    #[cfg(feature = "bevy_asset")]
     #[derive(Reflect, TypeUuid)]
     #[uuid = "a33abc11-264e-4bbb-82e8-b87226bb4383"]
     struct DummyAsset {
@@ -560,6 +571,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "bevy_asset")]
     impl Lens<DummyAsset> for DummyLens {
         fn lerp(&mut self, target: &mut DummyAsset, ratio: f32) {
             target.value = self.start.lerp(&self.end, &ratio);
@@ -702,6 +714,7 @@ mod tests {
     }
 
     /// AssetAnimator::new()
+    #[cfg(feature = "bevy_asset")]
     #[test]
     fn asset_animator_new() {
         let tween = Tween::<DummyAsset>::new(
@@ -717,6 +730,7 @@ mod tests {
     }
 
     /// AssetAnimator::with_state()
+    #[cfg(feature = "bevy_asset")]
     #[test]
     fn asset_animator_with_state() {
         for state in [AnimatorState::Playing, AnimatorState::Paused] {
@@ -733,6 +747,7 @@ mod tests {
     }
 
     /// AssetAnimator::default() + AssetAnimator::set_tweenable()
+    #[cfg(feature = "bevy_asset")]
     #[test]
     fn asset_animator_default() {
         let mut animator = AssetAnimator::<DummyAsset>::default();
@@ -753,6 +768,7 @@ mod tests {
     }
 
     /// AssetAnimator control playback
+    #[cfg(feature = "bevy_asset")]
     #[test]
     fn asset_animator_controls() {
         let tween = Tween::new(

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1269,13 +1269,13 @@ mod tests {
         let mut seq = Sequence::new((0..3).map(|i| {
             Tween::new(
                 EaseMethod::Linear,
+                TweeningType::Once,
                 Duration::from_secs(1),
                 TransformPositionLens {
                     start: Vec3::splat(i as f32),
                     end: Vec3::splat((i + 1) as f32),
                 },
             )
-            .with_repeat_count(RepeatCount::Finite(1))
         }));
         let mut transform = Transform::default();
 

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use bevy::prelude::*;
 
-use crate::{EaseMethod, Lens, RepeatCount, RepeatStrategy, TweeningDirection};
+use crate::{EaseMethod, Lens, TweeningDirection, TweeningType};
 
 /// The dynamic tweenable type.
 ///
@@ -28,6 +28,7 @@ use crate::{EaseMethod, Lens, RepeatCount, RepeatStrategy, TweeningDirection};
 /// # struct MyTweenable;
 /// # impl Tweenable<Transform> for MyTweenable {
 /// #     fn duration(&self) -> Duration  { unimplemented!() }
+/// #     fn is_looping(&self) -> bool  { unimplemented!() }
 /// #     fn set_progress(&mut self, progress: f32)  { unimplemented!() }
 /// #     fn progress(&self) -> f32  { unimplemented!() }
 /// #     fn tick(&mut self, delta: Duration, target: &mut Transform, entity: Entity, event_writer: &mut EventWriter<TweenCompleted>) -> TweenState  { unimplemented!() }
@@ -59,20 +60,20 @@ pub enum TweenState {
     /// The tweenable is still active, and did not reach its end state yet.
     Active,
     /// Animation reached its end state. The tweenable is idling at its latest
-    /// time.
-    ///
-    /// Note that [`RepeatCount::Infinite`] tweenables never reach this state.
+    /// time. This can only happen for [`TweeningType::Once`], since other
+    /// types loop indefinitely.
     Completed,
 }
 
 /// Event raised when a tween completed.
 ///
-/// This event is raised when a tween completed. When looping, this is raised
-/// once per iteration. In case the animation direction changes
-/// ([`RepeatStrategy::MirroredRepeat`]), an iteration corresponds to a single
-/// progress from one endpoint to the other, whatever the direction. Therefore a
-/// complete cycle start -> end -> start counts as 2 iterations and raises 2
-/// events (one when reaching the end, one when reaching back the start).
+/// This event is raised when a tween completed. For non-looping tweens, this is
+/// raised once at the end of the animation. For looping animations, this is
+/// raised once per iteration. In case the animation direction changes
+/// ([`TweeningType::PingPong`]), an iteration corresponds to a single progress
+/// from one endpoint to the other, whatever the direction. Therefore a complete
+/// cycle start -> end -> start counts as 2 iterations and raises 2 events (one
+/// when reaching the end, one when reaching back the start).
 ///
 /// # Note
 ///
@@ -96,79 +97,59 @@ pub struct TweenCompleted {
     pub user_data: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy)]
 struct AnimClock {
     elapsed: Duration,
     duration: Duration,
-    times_completed: u32,
-    total_duration: TotalDuration,
-    strategy: RepeatStrategy,
+    is_looping: bool,
 }
 
 impl AnimClock {
-    fn new(duration: Duration) -> Self {
+    fn new(duration: Duration, is_looping: bool) -> Self {
         Self {
             elapsed: Duration::ZERO,
             duration,
-            total_duration: compute_total_duration(duration, RepeatCount::default()),
-            times_completed: 0,
-            strategy: RepeatStrategy::default(),
+            is_looping,
         }
     }
 
-    fn record_completions(&mut self, times_completed: u32) {
-        self.times_completed = self.times_completed.saturating_add(times_completed);
-    }
+    fn tick(&mut self, duration: Duration) -> u32 {
+        self.elapsed = self.elapsed.saturating_add(duration);
 
-    fn tick(&mut self, tick: Duration) -> u32 {
-        let duration = self.duration.as_nanos();
+        if self.elapsed < self.duration {
+            0
+        } else if self.is_looping {
+            let elapsed = self.elapsed.as_nanos();
+            let duration = self.duration.as_nanos();
 
-        let before = self.elapsed.as_nanos() / duration;
-        self.elapsed = self.elapsed.saturating_add(tick);
-        if let TotalDuration::Finite(duration) = self.total_duration {
-            self.elapsed = self.elapsed.min(duration);
+            self.elapsed = Duration::from_nanos((elapsed % duration) as u64);
+            (elapsed / duration) as u32
+        } else {
+            self.elapsed = self.duration;
+            1
         }
-        (self.elapsed.as_nanos() / duration - before) as u32
     }
 
     fn set_progress(&mut self, progress: f32) {
-        self.elapsed = self.duration.mul_f32(progress.max(0.));
+        let progress = if self.is_looping {
+            progress.max(0.).fract()
+        } else {
+            progress.clamp(0., 1.)
+        };
+
+        self.elapsed = self.duration.mul_f32(progress);
     }
 
     fn progress(&self) -> f32 {
         self.elapsed.as_secs_f32() / self.duration.as_secs_f32()
     }
 
-    fn state(&self) -> TweenState {
-        match self.total_duration {
-            TotalDuration::Finite(duration) => {
-                if self.elapsed >= duration {
-                    TweenState::Completed
-                } else {
-                    TweenState::Active
-                }
-            }
-            TotalDuration::Infinite => TweenState::Active,
-        }
+    fn completed(&self) -> bool {
+        self.elapsed >= self.duration
     }
 
     fn reset(&mut self) {
-        self.times_completed = 0;
         self.elapsed = Duration::ZERO;
-    }
-}
-
-#[derive(Debug)]
-enum TotalDuration {
-    Finite(Duration),
-    Infinite,
-}
-
-fn compute_total_duration(duration: Duration, count: RepeatCount) -> TotalDuration {
-    match count {
-        RepeatCount::Finite(times) => TotalDuration::Finite(duration.saturating_mul(times)),
-        RepeatCount::For(duration) => TotalDuration::Finite(duration),
-        RepeatCount::Infinite => TotalDuration::Infinite,
     }
 }
 
@@ -176,13 +157,21 @@ fn compute_total_duration(duration: Duration, count: RepeatCount) -> TotalDurati
 pub trait Tweenable<T>: Send + Sync {
     /// Get the total duration of the animation.
     ///
-    /// This is always the duration of a single iteration, even when looping.
+    /// For non-looping tweenables ([`TweeningType::Once`]), this is the total
+    /// animation duration. For looping ones, this is the duration of a
+    /// single iteration, since the total animation duration is infinite.
     ///
-    /// Note that for [`RepeatStrategy::MirroredRepeat`], this is the duration
-    /// of a single way, either from start to end or back from end to start.
-    /// The total "loop" duration start -> end -> start to reach back the
-    /// same state in this case is the double of the returned value.
+    /// Note that for [`TweeningType::PingPong`], this is the duration of a
+    /// single way, either from start to end or back from end to start. The
+    /// total "loop" duration start -> end -> start to reach back the same
+    /// state in this case is the double of the returned value.
     fn duration(&self) -> Duration;
+
+    /// Return `true` if the animation is looping.
+    ///
+    /// Looping tweenables are of type [`TweeningType::Loop`] or
+    /// [`TweeningType::PingPong`].
+    fn is_looping(&self) -> bool;
 
     /// Set the current animation playback progress.
     ///
@@ -191,12 +180,20 @@ pub trait Tweenable<T>: Send + Sync {
     /// [`progress()`]: Tweenable::progress
     fn set_progress(&mut self, progress: f32);
 
-    /// Get the current progress in \[0:1\] of the animation.
+    /// Get the current progress in \[0:1\] (non-looping) or \[0:1\[ (looping)
+    /// of the animation.
     ///
-    /// While looping, the exact value `1.0` is never reached, since the
-    /// tweenable loops over to `0.0` immediately when it changes direction at
-    /// either endpoint. Upon completion, the tweenable always reports exactly
-    /// `1.0`.
+    /// For looping animations, this reports the progress of the current
+    /// iteration, in the current direction:
+    /// - [`TweeningType::Loop`] is `0` at start and `1` at end. The exact value
+    ///   `1.0` is never reached, since the tweenable loops over to `0.0`
+    ///   immediately.
+    /// - [`TweeningType::PingPong`] is `0` at the source endpoint and `1` and
+    ///   the destination one, which are respectively the start/end for
+    ///   [`TweeningDirection::Forward`], or the end/start for
+    ///   [`TweeningDirection::Backward`]. The exact value `1.0` is never
+    ///   reached, since the tweenable loops over to `0.0` immediately when it
+    ///   changes direction at either endpoint.
     fn progress(&self) -> f32;
 
     /// Tick the animation, advancing it by the given delta time and mutating
@@ -226,10 +223,10 @@ pub trait Tweenable<T>: Send + Sync {
     /// Get the number of times this tweenable completed.
     ///
     /// For looping animations, this returns the number of times a single
-    /// playback was completed. In the case of
-    /// [`RepeatStrategy::MirroredRepeat`] this corresponds to a playback in
-    /// a single direction, so tweening from start to end and back to start
-    /// counts as two completed times (one forward, one backward).
+    /// playback was completed. In the case of [`TweeningType::PingPong`]
+    /// this corresponds to a playback in a single direction, so tweening
+    /// from start to end and back to start counts as two completed times (one
+    /// forward, one backward).
     fn times_completed(&self) -> u32;
 
     /// Rewind the animation to its starting state.
@@ -273,6 +270,8 @@ pub type CompletedCallback<T> = dyn Fn(Entity, &Tween<T>) + Send + Sync + 'stati
 pub struct Tween<T> {
     ease_function: EaseMethod,
     clock: AnimClock,
+    times_completed: u32,
+    tweening_type: TweeningType,
     direction: TweeningDirection,
     lens: Box<dyn Lens<T> + Send + Sync + 'static>,
     on_completed: Option<Box<CompletedCallback<T>>>,
@@ -290,6 +289,7 @@ impl<T: 'static> Tween<T> {
     /// # use std::time::Duration;
     /// let tween1 = Tween::new(
     ///     EaseFunction::QuadraticInOut,
+    ///     TweeningType::Once,
     ///     Duration::from_secs_f32(1.0),
     ///     TransformPositionLens {
     ///         start: Vec3::ZERO,
@@ -298,6 +298,7 @@ impl<T: 'static> Tween<T> {
     /// );
     /// let tween2 = Tween::new(
     ///     EaseFunction::QuadraticInOut,
+    ///     TweeningType::Once,
     ///     Duration::from_secs_f32(1.0),
     ///     TransformRotationLens {
     ///         start: Quat::IDENTITY,
@@ -322,6 +323,7 @@ impl<T> Tween<T> {
     /// # use std::time::Duration;
     /// let tween = Tween::new(
     ///     EaseFunction::QuadraticInOut,
+    ///     TweeningType::Once,
     ///     Duration::from_secs_f32(1.0),
     ///     TransformPositionLens {
     ///         start: Vec3::ZERO,
@@ -330,13 +332,20 @@ impl<T> Tween<T> {
     /// );
     /// ```
     #[must_use]
-    pub fn new<L>(ease_function: impl Into<EaseMethod>, duration: Duration, lens: L) -> Self
+    pub fn new<L>(
+        ease_function: impl Into<EaseMethod>,
+        tweening_type: TweeningType,
+        duration: Duration,
+        lens: L,
+    ) -> Self
     where
         L: Lens<T> + Send + Sync + 'static,
     {
         Self {
             ease_function: ease_function.into(),
-            clock: AnimClock::new(duration),
+            clock: AnimClock::new(duration, tweening_type != TweeningType::Once),
+            times_completed: 0,
+            tweening_type,
             direction: TweeningDirection::Forward,
             lens: Box::new(lens),
             on_completed: None,
@@ -358,6 +367,7 @@ impl<T> Tween<T> {
     /// let tween = Tween::new(
     ///     // [...]
     /// #    EaseFunction::QuadraticInOut,
+    /// #    TweeningType::Once,
     /// #    Duration::from_secs_f32(1.0),
     /// #    TransformPositionLens {
     /// #        start: Vec3::ZERO,
@@ -415,20 +425,6 @@ impl<T> Tween<T> {
         self.direction
     }
 
-    /// Set the number of times to repeat the animation.
-    #[must_use]
-    pub fn with_repeat_count(mut self, count: RepeatCount) -> Self {
-        self.clock.total_duration = compute_total_duration(self.clock.duration, count);
-        self
-    }
-
-    /// Choose how the animation behaves upon a repetition.
-    #[must_use]
-    pub fn with_repeat_strategy(mut self, strategy: RepeatStrategy) -> Self {
-        self.clock.strategy = strategy;
-        self
-    }
-
     /// Set a callback invoked when the animation completes.
     ///
     /// The callback when invoked receives as parameters the [`Entity`] on which
@@ -473,6 +469,10 @@ impl<T> Tweenable<T> for Tween<T> {
         self.clock.duration
     }
 
+    fn is_looping(&self) -> bool {
+        self.tweening_type != TweeningType::Once
+    }
+
     fn set_progress(&mut self, progress: f32) {
         self.clock.set_progress(progress);
     }
@@ -488,17 +488,22 @@ impl<T> Tweenable<T> for Tween<T> {
         entity: Entity,
         event_writer: &mut EventWriter<TweenCompleted>,
     ) -> TweenState {
-        if self.clock.state() == TweenState::Completed {
+        if !self.is_looping() && self.clock.completed() {
             return TweenState::Completed;
         }
 
         // Tick the animation clock
         let times_completed = self.clock.tick(delta);
-        self.clock.record_completions(times_completed);
-        if self.clock.strategy == RepeatStrategy::MirroredRepeat && times_completed & 1 != 0 {
+        self.times_completed += times_completed;
+        if times_completed & 1 != 0 && self.tweening_type == TweeningType::PingPong {
             self.direction = !self.direction;
         }
-        let progress = self.progress();
+        let state = if self.is_looping() || times_completed == 0 {
+            TweenState::Active
+        } else {
+            TweenState::Completed
+        };
+        let progress = self.clock.progress();
 
         // Apply the lens, even if the animation finished, to ensure the state is
         // consistent
@@ -522,15 +527,16 @@ impl<T> Tweenable<T> for Tween<T> {
             }
         }
 
-        self.clock.state()
+        state
     }
 
     fn times_completed(&self) -> u32 {
-        self.clock.times_completed
+        self.times_completed
     }
 
     fn rewind(&mut self) {
         self.clock.reset();
+        self.times_completed = 0;
     }
 }
 
@@ -615,6 +621,10 @@ impl<T> Sequence<T> {
 impl<T> Tweenable<T> for Sequence<T> {
     fn duration(&self) -> Duration {
         self.duration
+    }
+
+    fn is_looping(&self) -> bool {
+        false // TODO - implement looping sequences...
     }
 
     fn set_progress(&mut self, progress: f32) {
@@ -723,6 +733,10 @@ impl<T> Tweenable<T> for Tracks<T> {
         self.duration
     }
 
+    fn is_looping(&self) -> bool {
+        false // TODO - implement looping tracks...
+    }
+
     fn set_progress(&mut self, progress: f32) {
         self.times_completed = if progress >= 1. { 1 } else { 0 }; // not looping
         let progress = progress.clamp(0., 1.); // not looping
@@ -804,6 +818,10 @@ impl<T> Tweenable<T> for Delay {
         self.timer.duration()
     }
 
+    fn is_looping(&self) -> bool {
+        false
+    }
+
     fn set_progress(&mut self, progress: f32) {
         // need to reset() to clear finished() unfortunately
         self.timer.reset();
@@ -873,8 +891,7 @@ mod tests {
     #[test]
     fn anim_clock_precision() {
         let duration = Duration::from_millis(1);
-        let mut clock = AnimClock::new(duration);
-        clock.total_duration = TotalDuration::Infinite;
+        let mut clock = AnimClock::new(duration, true);
 
         let test_ticks = [
             Duration::from_micros(123),
@@ -905,29 +922,27 @@ mod tests {
     #[test]
     fn tween_tick() {
         for tweening_direction in &[TweeningDirection::Forward, TweeningDirection::Backward] {
-            for (count, strategy) in &[
-                (RepeatCount::Finite(1), RepeatStrategy::default()),
-                (RepeatCount::Infinite, RepeatStrategy::Repeat),
-                (RepeatCount::Finite(2), RepeatStrategy::Repeat),
-                (RepeatCount::Infinite, RepeatStrategy::MirroredRepeat),
-                (RepeatCount::Finite(2), RepeatStrategy::MirroredRepeat),
+            for tweening_type in &[
+                TweeningType::Once,
+                TweeningType::Loop,
+                TweeningType::PingPong,
             ] {
                 println!(
-                    "TweeningType: count={count:?} strategy={strategy:?} dir={tweening_direction:?}",
+                    "TweeningType: type={:?} dir={:?}",
+                    tweening_type, tweening_direction
                 );
 
                 // Create a linear tween over 1 second
                 let mut tween = Tween::new(
                     EaseMethod::Linear,
+                    *tweening_type,
                     Duration::from_secs_f32(1.0),
                     TransformPositionLens {
                         start: Vec3::ZERO,
                         end: Vec3::ONE,
                     },
                 )
-                .with_direction(*tweening_direction)
-                .with_repeat_count(*count)
-                .with_repeat_strategy(*strategy);
+                .with_direction(*tweening_direction);
                 assert_eq!(tween.direction(), *tweening_direction);
                 assert!(tween.on_completed.is_none());
                 assert!(tween.event_data.is_none());
@@ -967,8 +982,8 @@ mod tests {
                 for i in 1..=11 {
                     // Calculate expected values
                     let (progress, times_completed, mut direction, expected_state, just_completed) =
-                        match count {
-                            RepeatCount::Finite(1) => {
+                        match tweening_type {
+                            TweeningType::Once => {
                                 let progress = (i as f32 * 0.2).min(1.0);
                                 let times_completed = if i >= 5 { 1 } else { 0 };
                                 let state = if i < 5 {
@@ -985,77 +1000,37 @@ mod tests {
                                     just_completed,
                                 )
                             }
-                            RepeatCount::Finite(count) => {
-                                let progress = (i as f32 * 0.2).min(1.0 * *count as f32);
-                                if *strategy == RepeatStrategy::Repeat {
-                                    let times_completed = i / 5;
-                                    let just_completed = i % 5 == 0;
-                                    (
-                                        progress,
-                                        times_completed,
-                                        TweeningDirection::Forward,
-                                        if i < 10 {
-                                            TweenState::Active
-                                        } else {
-                                            TweenState::Completed
-                                        },
-                                        just_completed,
-                                    )
-                                } else {
-                                    let i5 = i % 5;
-                                    let times_completed = i / 5;
-                                    let i10 = i % 10;
-                                    let direction = if i10 >= 5 {
-                                        TweeningDirection::Backward
-                                    } else {
-                                        TweeningDirection::Forward
-                                    };
-                                    let just_completed = i5 == 0;
-                                    (
-                                        progress,
-                                        times_completed,
-                                        direction,
-                                        if i < 10 {
-                                            TweenState::Active
-                                        } else {
-                                            TweenState::Completed
-                                        },
-                                        just_completed,
-                                    )
-                                }
+                            TweeningType::Loop => {
+                                let progress = (i as f32 * 0.2).fract();
+                                let times_completed = i / 5;
+                                let just_completed = i % 5 == 0;
+                                (
+                                    progress,
+                                    times_completed,
+                                    TweeningDirection::Forward,
+                                    TweenState::Active,
+                                    just_completed,
+                                )
                             }
-                            RepeatCount::Infinite => {
-                                let progress = i as f32 * 0.2;
-                                if *strategy == RepeatStrategy::Repeat {
-                                    let times_completed = i / 5;
-                                    let just_completed = i % 5 == 0;
-                                    (
-                                        progress,
-                                        times_completed,
-                                        TweeningDirection::Forward,
-                                        TweenState::Active,
-                                        just_completed,
-                                    )
+                            TweeningType::PingPong => {
+                                let i5 = i % 5;
+                                let progress = i5 as f32 * 0.2;
+                                let times_completed = i / 5;
+                                let i10 = i % 10;
+                                let direction = if i10 >= 5 {
+                                    TweeningDirection::Backward
                                 } else {
-                                    let i5 = i % 5;
-                                    let times_completed = i / 5;
-                                    let i10 = i % 10;
-                                    let direction = if i10 >= 5 {
-                                        TweeningDirection::Backward
-                                    } else {
-                                        TweeningDirection::Forward
-                                    };
-                                    let just_completed = i5 == 0;
-                                    (
-                                        progress,
-                                        times_completed,
-                                        direction,
-                                        TweenState::Active,
-                                        just_completed,
-                                    )
-                                }
+                                    TweeningDirection::Forward
+                                };
+                                let just_completed = i5 == 0;
+                                (
+                                    progress,
+                                    times_completed,
+                                    direction,
+                                    TweenState::Active,
+                                    just_completed,
+                                )
                             }
-                            RepeatCount::For(_) => panic!("Untested"),
                         };
                     let factor = if tweening_direction.is_backward() {
                         direction = !direction;
@@ -1093,6 +1068,7 @@ mod tests {
 
                     // Check actual values
                     assert_eq!(tween.direction(), direction);
+                    assert_eq!(tween.is_looping(), *tweening_type != TweeningType::Once);
                     assert_eq!(actual_state, expected_state);
                     assert!(abs_diff_eq(tween.progress(), progress, 1e-5));
                     assert_eq!(tween.times_completed(), times_completed);
@@ -1121,6 +1097,7 @@ mod tests {
                 // Rewind
                 tween.rewind();
                 assert_eq!(tween.direction(), *tweening_direction); // does not change
+                assert_eq!(tween.is_looping(), *tweening_type != TweeningType::Once);
                 assert!(abs_diff_eq(tween.progress(), 0., 1e-5));
                 assert_eq!(tween.times_completed(), 0);
 
@@ -1156,6 +1133,7 @@ mod tests {
     fn tween_dir() {
         let mut tween = Tween::new(
             EaseMethod::Linear,
+            TweeningType::Once,
             Duration::from_secs_f32(1.0),
             TransformPositionLens {
                 start: Vec3::ZERO,
@@ -1213,6 +1191,7 @@ mod tests {
     fn seq_tick() {
         let tween1 = Tween::new(
             EaseMethod::Linear,
+            TweeningType::Once,
             Duration::from_secs_f32(1.0),
             TransformPositionLens {
                 start: Vec3::ZERO,
@@ -1221,6 +1200,7 @@ mod tests {
         );
         let tween2 = Tween::new(
             EaseMethod::Linear,
+            TweeningType::Once,
             Duration::from_secs_f32(1.0),
             TransformRotationLens {
                 start: Quat::IDENTITY,
@@ -1251,13 +1231,13 @@ mod tests {
             } else if i < 10 {
                 assert_eq!(state, TweenState::Active);
                 let alpha_deg = (18 * (i - 5)) as f32;
-                assert!(transform.translation.abs_diff_eq(Vec3::ONE, 1e-5));
+                assert!(transform.translation.abs_diff_eq(Vec3::splat(1.), 1e-5));
                 assert!(transform
                     .rotation
                     .abs_diff_eq(Quat::from_rotation_x(alpha_deg.to_radians()), 1e-5));
             } else {
                 assert_eq!(state, TweenState::Completed);
-                assert!(transform.translation.abs_diff_eq(Vec3::ONE, 1e-5));
+                assert!(transform.translation.abs_diff_eq(Vec3::splat(1.), 1e-5));
                 assert!(transform
                     .rotation
                     .abs_diff_eq(Quat::from_rotation_x(90_f32.to_radians()), 1e-5));
@@ -1271,6 +1251,7 @@ mod tests {
         let mut seq = Sequence::new((1..5).map(|i| {
             Tween::new(
                 EaseMethod::Linear,
+                TweeningType::Once,
                 Duration::from_secs_f32(0.2 * i as f32),
                 TransformPositionLens {
                     start: Vec3::ZERO,
@@ -1278,6 +1259,7 @@ mod tests {
                 },
             )
         }));
+        assert!(!seq.is_looping());
 
         let mut progress = 0.;
         for i in 1..5 {
@@ -1300,6 +1282,7 @@ mod tests {
     fn tracks_tick() {
         let tween1 = Tween::new(
             EaseMethod::Linear,
+            TweeningType::Once,
             Duration::from_secs_f32(1.),
             TransformPositionLens {
                 start: Vec3::ZERO,
@@ -1308,6 +1291,7 @@ mod tests {
         );
         let tween2 = Tween::new(
             EaseMethod::Linear,
+            TweeningType::Once,
             Duration::from_secs_f32(0.8), // shorter
             TransformRotationLens {
                 start: Quat::IDENTITY,
@@ -1316,6 +1300,7 @@ mod tests {
         );
         let mut tracks = Tracks::new([tween1, tween2]);
         assert_eq!(tracks.duration(), Duration::from_secs_f32(1.)); // max(1., 0.8)
+        assert!(!tracks.is_looping());
 
         let mut transform = Transform::default();
 
@@ -1347,7 +1332,7 @@ mod tests {
                 assert_eq!(state, TweenState::Completed);
                 assert_eq!(tracks.times_completed(), 1);
                 assert!((tracks.progress() - 1.).abs() < 1e-5);
-                assert!(transform.translation.abs_diff_eq(Vec3::ONE, 1e-5));
+                assert!(transform.translation.abs_diff_eq(Vec3::splat(1.), 1e-5));
                 assert!(transform
                     .rotation
                     .abs_diff_eq(Quat::from_rotation_x(90_f32.to_radians()), 1e-5));
@@ -1403,6 +1388,7 @@ mod tests {
         {
             let tweenable: &dyn Tweenable<Transform> = &delay;
             assert_eq!(tweenable.duration(), duration);
+            assert!(!tweenable.is_looping());
             assert!(tweenable.progress().abs() < 1e-5);
         }
 

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -650,26 +650,28 @@ impl<T> Tweenable<T> for Sequence<T> {
 
     fn tick(
         &mut self,
-        mut delta: Duration,
+        delta: Duration,
         target: &mut T,
         entity: Entity,
         event_writer: &mut EventWriter<TweenCompleted>,
     ) -> TweenState {
-        self.time = (self.time + delta).min(self.duration);
-        while self.index < self.tweens.len() {
+        if self.index < self.tweens.len() {
+            let mut state = TweenState::Active;
+            self.time = (self.time + delta).min(self.duration);
             let tween = &mut self.tweens[self.index];
-            let tween_remaining = tween.duration().mul_f32(1.0 - tween.progress());
-            if let TweenState::Active = tween.tick(delta, target, entity, event_writer) {
-                return TweenState::Active;
+            let tween_state = tween.tick(delta, target, entity, event_writer);
+            if tween_state == TweenState::Completed {
+                tween.rewind();
+                self.index += 1;
+                if self.index >= self.tweens.len() {
+                    state = TweenState::Completed;
+                    self.times_completed = 1;
+                }
             }
-
-            tween.rewind();
-            delta -= tween_remaining;
-            self.index += 1;
+            state
+        } else {
+            TweenState::Completed
         }
-
-        self.times_completed = 1;
-        TweenState::Completed
     }
 
     fn times_completed(&self) -> u32 {
@@ -1261,45 +1263,6 @@ mod tests {
                     .abs_diff_eq(Quat::from_rotation_x(90_f32.to_radians()), 1e-5));
             }
         }
-    }
-
-    /// Test crossing tween boundaries in one tick.
-    #[test]
-    fn seq_tick_boundaries() {
-        let mut seq = Sequence::new((0..3).map(|i| {
-            Tween::new(
-                EaseMethod::Linear,
-                TweeningType::Once,
-                Duration::from_secs(1),
-                TransformPositionLens {
-                    start: Vec3::splat(i as f32),
-                    end: Vec3::splat((i + 1) as f32),
-                },
-            )
-        }));
-        let mut transform = Transform::default();
-
-        // Dummy world and event writer
-        let mut world = World::new();
-        world.insert_resource(Events::<TweenCompleted>::default());
-        let mut system_state: SystemState<EventWriter<TweenCompleted>> =
-            SystemState::new(&mut world);
-        let mut event_writer = system_state.get_mut(&mut world);
-
-        // Tick halfway through the first tween, then in one tick:
-        // - Finish the first tween
-        // - Start and finish the second tween
-        // - Start the third tween
-        for delta in [0.5, 2.0] {
-            seq.tick(
-                Duration::from_secs_f32(delta),
-                &mut transform,
-                Entity::from_raw(0),
-                &mut event_writer,
-            );
-        }
-        assert_eq!(seq.index(), 2);
-        assert!(transform.translation.abs_diff_eq(Vec3::splat(2.5), 1e-5));
     }
 
     /// Sequence::new() and various Sequence-specific methods


### PR DESCRIPTION
Upgrade to the latest released version 0.8.0 of Bevy.

Add a new `bevy_asset` feature to enable animation of Bevy assets
(types implementing the `Asset` trait). Bevy 0.8 does not contain
`bevy_asset` in its defaul features, so this new feature reflects that
new possibility to build Bevy and 🍃 Bevy Tweening without support
for the `bevy_asset` crate. The new feature is enabled by default for
discoverability and to prevent a behavior breaking change.
