### PR TITLE
Fix repeat mode broken after first iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `tweening_type` parameter from the signature of `Tween<T>::new()`; use `with_repeat_count()` and `with_repeat_strategy()` instead.
 - Animators now always have a tween (instead of it being optional). This means the default animator implementation was removed.
 - `Delay::new()` now panics if the `duration` is zero. This prevents creating no-op `Delay` objects, and avoids an internal edge case producing wrong results.
+- Tweens moving to `TweenState::Completed` are now guaranteed to freeze their state. In particular, this means that their direction will not flip at the end of the last loop if their repeat strategy is `RepeatStrategy::MirroredRepeat`.
 
 ### Removed
 
 - Removed `Tweenable::is_looping()`, which was not implemented for most tweenables.
 - Removed `TweeningType` in favor of `RepeatCount` and `RepeatStrategy`.
+
+### Fixed
+
+- Fixed `Tween::rewind()` restoring the original tween's direction even when using `RepeatStrategy::MirroredRepeat`.
 
 ## [0.5.0] - 2022-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `Tweenable::is_looping()`, which was not implemented for most tweenables.
 - Removed `TweeningType` in favor of `RepeatCount` and `RepeatStrategy`.
 
-### Fixed
-
-- Fixed `Tween::rewind()` restoring the original tween's direction even when using `RepeatStrategy::MirroredRepeat`.
-
 ## [0.5.0] - 2022-08-04
 
 ### Added


### PR DESCRIPTION
Fix the repeat mode being broken after the first iteration due to
`AnimClock::progress()` reporting a progress greater than `1.`, which was
breaking the logic of `Tween` and `Lens`.

Also fix `Tween::rewind()` not restoring the original tween direction when
using a repeat strategy of `RepeatStrategy::MirroredRepeat`.

Fixes #42
