### PR TITLE
Add `close_on_esc()` system to all examples

### DIFF
--- a/examples/colormaterial_color.rs
+++ b/examples/colormaterial_color.rs
@@ -15,6 +15,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_startup_system(setup)
         .run();

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -13,6 +13,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_plugin(WorldInspectorPlugin::new())
         .add_startup_system(setup)

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -14,6 +14,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_startup_system(setup)
         .add_system(update_text)

--- a/examples/sprite_color.rs
+++ b/examples/sprite_color.rs
@@ -11,6 +11,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_startup_system(setup)
         .run();

--- a/examples/text_color.rs
+++ b/examples/text_color.rs
@@ -14,6 +14,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_startup_system(setup)
         .run();

--- a/examples/transform_rotation.rs
+++ b/examples/transform_rotation.rs
@@ -13,6 +13,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_plugin(InspectorPlugin::<Options>::new())
         .add_startup_system(setup)

--- a/examples/transform_translation.rs
+++ b/examples/transform_translation.rs
@@ -13,6 +13,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_plugin(InspectorPlugin::<Options>::new())
         .add_startup_system(setup)

--- a/examples/ui_position.rs
+++ b/examples/ui_position.rs
@@ -13,6 +13,7 @@ fn main() {
             ..default()
         })
         .add_plugins(DefaultPlugins)
+        .add_system(bevy::window::close_on_esc)
         .add_plugin(TweeningPlugin)
         .add_plugin(InspectorPlugin::<Options>::new())
         .add_startup_system(setup)


### PR DESCRIPTION
Make it easy to exit an example with the ESC key by adding the built-in
`bevy::window::close_on_esc()` system to all examples.