### PR TITLE
Add `assert_approx_eq!()` testing macro

### DIFF
--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -14,11 +14,12 @@ const INIT_TRANSITION_DONE: u64 = 1;
 /// are only enabled after appearance animations finished.
 ///
 /// The logic is handled as:
-/// 1. Appearance animations send a `TweenComplete` event with `INIT_TRANSITION_DONE`
-/// 2. The `enable_interaction_after_initial_animation` system adds a label component
-/// `InitTransitionDone` to any button component which completed its appearance animation,
-/// to mark it as active.
-/// 3. The `interaction` system only queries buttons with a `InitTransitionDone` marker.
+/// 1. Appearance animations send a `TweenComplete` event with
+/// `INIT_TRANSITION_DONE` 2. The `enable_interaction_after_initial_animation`
+/// system adds a label component `InitTransitionDone` to any button component
+/// which completed its appearance animation, to mark it as active.
+/// 3. The `interaction` system only queries buttons with a `InitTransitionDone`
+/// marker.
 fn main() {
     App::default()
         .insert_resource(WindowDescriptor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,9 @@ pub mod lens;
 mod plugin;
 mod tweenable;
 
+#[cfg(test)]
+mod test_utils;
+
 /// How many times to repeat a tween animation. See also: [`RepeatStrategy`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepeatCount {
@@ -475,12 +478,8 @@ mod tests {
     #[cfg(feature = "bevy_asset")]
     use bevy::reflect::TypeUuid;
 
-    use super::{lens::*, *};
-
-    /// Utility to compare floating-point values with a tolerance.
-    fn abs_diff_eq(a: f32, b: f32, tol: f32) -> bool {
-        (a - b).abs() < tol
-    }
+    use super::*;
+    use crate::test_utils::*;
 
     struct DummyLens {
         start: f32,
@@ -511,7 +510,7 @@ mod tests {
         let mut l = DummyLens { start: 0., end: 1. };
         for r in [0_f32, 0.01, 0.3, 0.5, 0.9, 0.999, 1.] {
             l.lerp(&mut c, r);
-            assert!(abs_diff_eq(c.value, r, 1e-5));
+            assert_approx_eq!(c.value, r);
         }
     }
 
@@ -529,7 +528,7 @@ mod tests {
         let mut l = DummyLens { start: 0., end: 1. };
         for r in [0_f32, 0.01, 0.3, 0.5, 0.9, 0.999, 1.] {
             l.lerp(&mut a, r);
-            assert!(abs_diff_eq(a.value, r, 1e-5));
+            assert_approx_eq!(a.value, r);
         }
     }
 
@@ -628,32 +627,32 @@ mod tests {
         );
         let mut animator = Animator::new(tween);
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.tweenable_mut().set_progress(0.5);
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.5);
 
         animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.tweenable_mut().set_progress(0.5);
         animator.state = AnimatorState::Playing;
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.5);
 
         animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
     }
 
     #[test]
@@ -665,10 +664,10 @@ mod tests {
         );
 
         let mut animator = Animator::new(tween);
-        assert!(abs_diff_eq(animator.speed(), 1., 1e-5)); // default speed
+        assert_approx_eq!(animator.speed(), 1.); // default speed
 
         animator.set_speed(2.4);
-        assert!(abs_diff_eq(animator.speed(), 2.4, 1e-5));
+        assert_approx_eq!(animator.speed(), 2.4);
 
         let tween = Tween::<DummyComponent>::new(
             EaseFunction::QuadraticInOut,
@@ -677,7 +676,7 @@ mod tests {
         );
 
         let animator = Animator::new(tween).with_speed(3.5);
-        assert!(abs_diff_eq(animator.speed(), 3.5, 1e-5));
+        assert_approx_eq!(animator.speed(), 3.5);
     }
 
     #[test]
@@ -746,32 +745,32 @@ mod tests {
         );
         let mut animator = AssetAnimator::new(Handle::<DummyAsset>::default(), tween);
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.tweenable_mut().set_progress(0.5);
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.5);
 
         animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.tweenable_mut().set_progress(0.5);
         animator.state = AnimatorState::Playing;
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!((animator.tweenable().progress() - 0.5).abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.5);
 
         animator.tweenable_mut().rewind();
         assert_eq!(animator.state, AnimatorState::Playing);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
 
         animator.stop();
         assert_eq!(animator.state, AnimatorState::Paused);
-        assert!(animator.tweenable().progress().abs() <= 1e-5);
+        assert_approx_eq!(animator.tweenable().progress(), 0.);
     }
 
     #[cfg(feature = "bevy_asset")]
@@ -784,10 +783,10 @@ mod tests {
         );
 
         let mut animator = AssetAnimator::new(Handle::<DummyAsset>::default(), tween);
-        assert!(abs_diff_eq(animator.speed(), 1., 1e-5)); // default speed
+        assert_approx_eq!(animator.speed(), 1.); // default speed
 
         animator.set_speed(2.4);
-        assert!(abs_diff_eq(animator.speed(), 2.4, 1e-5));
+        assert_approx_eq!(animator.speed(), 2.4);
 
         let tween = Tween::new(
             EaseFunction::QuadraticInOut,
@@ -796,7 +795,7 @@ mod tests {
         );
 
         let animator = AssetAnimator::new(Handle::<DummyAsset>::default(), tween).with_speed(3.5);
-        assert!(abs_diff_eq(animator.speed(), 3.5, 1e-5));
+        assert_approx_eq!(animator.speed(), 3.5);
     }
 
     #[cfg(feature = "bevy_asset")]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,51 @@
+/// Utility to compare floating-point values with a tolerance.
+pub(crate) fn abs_diff_eq(a: f32, b: f32, tol: f32) -> bool {
+    (a - b).abs() < tol
+}
+
+/// Assert that two floating-point quantities are approximately equal.
+///
+/// This macro asserts that the absolute difference between the two first
+/// arguments is strictly less than a tolerance factor, which can be explicitly
+/// passed as third argument or implicitly defaults to `1e-5`.
+///
+/// # Usage
+///
+/// ```
+/// let x = 3.500009;
+/// assert_approx_eq!(x, 3.5);       // default tolerance 1e-5
+///
+/// let x = 3.509;
+/// assert_approx_eq!(x, 3.5, 0.01); // explicit tolerance
+/// ```
+macro_rules! assert_approx_eq {
+    ($left:expr, $right:expr $(,)?) => {
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                assert!(
+                    abs_diff_eq(*left_val, *right_val, 1e-5),
+                    "assertion failed: expected={} actual={} delta={} tol=1e-5(default)",
+                    left_val,
+                    right_val,
+                    (left_val - right_val).abs(),
+                );
+            }
+        }
+    };
+    ($left:expr, $right:expr, $tol:expr $(,)?) => {
+        match (&$left, &$right, &$tol) {
+            (left_val, right_val, tol_val) => {
+                assert!(
+                    abs_diff_eq(*left_val, *right_val, *tol_val),
+                    "assertion failed: expected={} actual={} delta={} tol={}",
+                    left_val,
+                    right_val,
+                    (left_val - right_val).abs(),
+                    tol_val
+                );
+            }
+        }
+    };
+}
+
+pub(crate) use assert_approx_eq;


### PR DESCRIPTION
Clarify testing code and potential assertions message with the use of a new `assert_approx_eq!()` macro for `f32` equality check with a tolerance. The macro leverages `abs_diff_eq()` but produces a better assertion message in case of failure. It also allows skipping the tolerance parameter to use the default of `1e-5`, which is the "standard" tolerance to use for progress and other small-ish values that are expected to be equal but might be slightly off due to rounding errors.

This change ignores the complications of testing for floating-point equality in a generic way, which is too complex, and instead restrict the usage to values like progress (range [0:1]) and other small position values around the origin.