### PR TITLE
Add elapsed API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `RepeatCount` and `RepeatStrategy` for more granular control over animation looping.
 - Added `with_repeat_count()` and `with_repeat_strategy()` builder methods to `Tween<T>`.
 - Added a `speed()` getter on `Animator<T>` and `AssetAnimator<T>`.
+- Added `set_elapsed(Duration)` and `elapsed() -> Duration` to the `Tweenable<T>` trait. Those methods are preferable over `set_progress()` and `progress()` as they avoid the conversion to floating-point values and any rounding errors.
 
 ### Changed
 


### PR DESCRIPTION
Add two new methods to the `Tweenable<T>` trait:
- `set_elapsed(Duration)` sets the elapsed time of the tweenable. This is equivalent to `set_progress(duration().mul_f32(progress))`, with the added benefit of avoiding floating-point conversions and potential rounding errors resulting from it. `set_progress()` is now largely implemented in terms of and as a convenience wrapper to calling `set_elapsed()`.
- `elapsed()` which queries the elapsed time of the tweenable. This is equivalent to `duration().mul_f32(progress())`, again with better precision.

The elapsed API is the recommended way going forward to manipulate a tweenable's time outside of the normal `tick()` flow. It supersedes the progress API.

This change purposedly skips any discussion about what happens to completion events when `set_progress()` or now `set_elpased()` is called with a lower value than the current one to seek time back. This design issue is logged as #60 and is still pending. The change also partially addresses #31, but without removing any existing API or feature.