### PR TITLE
Move `TextColorLens` under a new `bevy_text` feat.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,10 @@ jobs:
         run: cargo test --no-default-features --features="bevy_sprite"
         env:
           CARGO_INCREMENTAL: 1
+      - name: Build & run tests (text)
+        run: cargo test --no-default-features --features="bevy_text"
+        env:
+          CARGO_INCREMENTAL: 1
       - name: Build & run tests (asset)
         run: cargo test --no-default-features --features="bevy_asset"
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `with_repeat_count()` and `with_repeat_strategy()` builder methods to `Tween<T>`.
 - Added a `speed()` getter on `Animator<T>` and `AssetAnimator<T>`.
 - Added `set_elapsed(Duration)` and `elapsed() -> Duration` to the `Tweenable<T>` trait. Those methods are preferable over `set_progress()` and `progress()` as they avoid the conversion to floating-point values and any rounding errors.
+- Added a new `bevy_text` feature for `Text`-related built-in lenses.
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Animators now always have a tween (instead of it being optional). This means the default animator implementation was removed.
 - `Delay::new()` now panics if the `duration` is zero. This prevents creating no-op `Delay` objects, and avoids an internal edge case producing wrong results.
 - Tweens moving to `TweenState::Completed` are now guaranteed to freeze their state. In particular, this means that their direction will not flip at the end of the last loop if their repeat strategy is `RepeatStrategy::MirroredRepeat`.
+- Moved the `TextColorLens` lens from the `bevy_ui` feature to the new `bevy_text` one, to allow using it without the Bevy UI crate.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tweening"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["François Mockers <mockersf@gmail.com>", "Jerome Humbert <djeedai@gmail.com>"]
 edition = "2021"
 description = "Tweening animation plugin for the Bevy game engine"
@@ -13,13 +13,15 @@ readme = "README.md"
 exclude = ["examples/*.gif", ".github", "release.md"]
 
 [features]
-default = ["bevy_sprite", "bevy_ui", "bevy_asset"]
+default = ["bevy_sprite", "bevy_ui", "bevy_asset", "bevy_text"]
 # Enable support for Asset animation
 bevy_asset = ["bevy/bevy_asset"]
 # Enable built-in lenses for Bevy sprites
 bevy_sprite = ["bevy/bevy_sprite", "bevy/bevy_render"]
 # Enable built-in lenses for Bevy UI
-bevy_ui = ["bevy/bevy_ui", "bevy/bevy_text", "bevy/bevy_render"]
+bevy_ui = ["bevy/bevy_ui", "bevy/bevy_render"]
+# Enable built-in lenses for Bevy Text
+bevy_text = ["bevy/bevy_text", "bevy/bevy_render"]
 
 [dependencies]
 interpolation = "0.2"
@@ -54,7 +56,7 @@ required-features = [ "bevy_ui", "bevy/bevy_winit" ]
 
 [[example]]
 name = "text_color"
-required-features = [ "bevy_ui", "bevy/bevy_winit" ]
+required-features = [ "bevy_text", "bevy/bevy_winit" ]
 
 [[example]]
 name = "sequence"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This crate supports the following features:
 | `bevy_asset`  | Yes | Enable animating Bevy assets (`Asset`) in addition of components. |
 | `bevy_sprite` | Yes | Includes built-in lenses for some `Sprite`-related components. |
 | `bevy_ui`     | Yes | Includes built-in lenses for some UI-related components. |
+| `bevy_text`   | Yes | Includes built-in lenses for some `Text`-related components. |
 
 ### System setup
 
@@ -121,7 +122,7 @@ The naming scheme for predefined lenses is `"<TargetName><FieldName>Lens"`, wher
 | | [`scale`](https://docs.rs/bevy/0.8.0/bevy/transform/components/struct.Transform.html#structfield.scale) | [`TransformScaleLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TransformScaleLens.html) | |
 | [`Sprite`](https://docs.rs/bevy/0.8.0/bevy/sprite/struct.Sprite.html) | [`color`](https://docs.rs/bevy/0.8.0/bevy/sprite/struct.Sprite.html#structfield.color) | [`SpriteColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.SpriteColorLens.html) | `bevy_sprite` |
 | [`Style`](https://docs.rs/bevy/0.8.0/bevy/ui/struct.Style.html) | [`position`](https://docs.rs/bevy/0.8.0/bevy/ui/struct.Style.html#structfield.position) | [`UiPositionLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.UiPositionLens.html) | `bevy_ui` |
-| [`Text`](https://docs.rs/bevy/0.8.0/bevy/text/struct.Text.html) | [`TextStyle::color`](https://docs.rs/bevy/0.8.0/bevy/text/struct.TextStyle.html#structfield.color) | [`TextColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TextColorLens.html) | `bevy_ui` |
+| [`Text`](https://docs.rs/bevy/0.8.0/bevy/text/struct.Text.html) | [`TextStyle::color`](https://docs.rs/bevy/0.8.0/bevy/text/struct.TextStyle.html#structfield.color) | [`TextColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/struct.TextColorLens.html) | `bevy_text` |
 
 ¹ Shortest-path interpolation between two rotations, using `Quat::slerp()`.
 

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -79,7 +79,7 @@ pub trait Lens<T> {
 ///
 /// [`color`]: https://docs.rs/bevy/0.8.0/bevy/text/struct.TextStyle.html#structfield.color
 /// [`Text`]: https://docs.rs/bevy/0.8.0/bevy/text/struct.Text.html
-#[cfg(feature = "bevy_ui")]
+#[cfg(feature = "bevy_text")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TextColorLens {
     /// Start color.
@@ -90,7 +90,7 @@ pub struct TextColorLens {
     pub section: usize,
 }
 
-#[cfg(feature = "bevy_ui")]
+#[cfg(feature = "bevy_text")]
 impl Lens<Text> for TextColorLens {
     fn lerp(&mut self, target: &mut Text, ratio: f32) {
         // Note: Add<f32> for Color affects alpha, but not Mul<f32>. So use Vec4 for
@@ -377,7 +377,7 @@ mod tests {
 
     use super::*;
 
-    #[cfg(feature = "bevy_ui")]
+    #[cfg(feature = "bevy_text")]
     #[test]
     fn text_color() {
         let mut lens = TextColorLens {


### PR DESCRIPTION
Add a new `bevy_text` feature for more granular control over `Text`-related lenses, and change the `TextColorLens` to require that new feature instead of `bevy_ui`, as texts _can_ be used without the Bevy UI crate.

Fixes #68