### PR TITLE
Take `impl Into<RepeatCount>` for easier usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unrelease]
+
+### Added
+
+- Added `From<u32>` and `From<Duration>` for `RepeatCount`, respectively yielding `RepeatCount::Finite(value)` and `RepeatCount::For(value)`.
+
+### Changed
+
+- Changed the signature of `with_repeat_count()` to take an `impl Into<RepeatCount>` instead of a `RepeatCount` by value.
+
 ## [0.6.0] - 2022-11-15
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,26 @@ pub enum RepeatCount {
     Infinite,
 }
 
-/// What to do when a tween animation needs to be repeated.
+impl Default for RepeatCount {
+    fn default() -> Self {
+        Self::Finite(1)
+    }
+}
+
+impl From<u32> for RepeatCount {
+    fn from(value: u32) -> Self {
+        Self::Finite(value)
+    }
+}
+
+impl From<Duration> for RepeatCount {
+    fn from(value: Duration) -> Self {
+        Self::For(value)
+    }
+}
+
+/// What to do when a tween animation needs to be repeated. See also
+/// [`RepeatCount`].
 ///
 /// Only applicable when [`RepeatCount`] is greater than the animation duration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -202,12 +221,6 @@ pub enum RepeatStrategy {
     /// is, a 1 second animation will take 2 seconds to end up back where it
     /// started.
     MirroredRepeat,
-}
-
-impl Default for RepeatCount {
-    fn default() -> Self {
-        Self::Finite(1)
-    }
 }
 
 impl Default for RepeatStrategy {

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -574,8 +574,8 @@ impl<T> Tween<T> {
 
     /// Set the number of times to repeat the animation.
     #[must_use]
-    pub fn with_repeat_count(mut self, count: RepeatCount) -> Self {
-        self.clock.total_duration = compute_total_duration(self.clock.duration, count);
+    pub fn with_repeat_count(mut self, count: impl Into<RepeatCount>) -> Self {
+        self.clock.total_duration = compute_total_duration(self.clock.duration, count.into());
         self
     }
 
@@ -1242,6 +1242,37 @@ mod tests {
         assert_eq!(
             (total_duration.as_secs_f64() / duration.as_secs_f64()) as i32,
             times_completed
+        );
+    }
+
+    #[test]
+    fn into_repeat_count() {
+        let tween = Tween::new(
+            EaseMethod::Linear,
+            Duration::from_secs(1),
+            TransformPositionLens {
+                start: Vec3::ZERO,
+                end: Vec3::ONE,
+            },
+        )
+        .with_repeat_count(5);
+        assert_eq!(
+            tween.total_duration(),
+            TotalDuration::Finite(Duration::from_secs(5))
+        );
+
+        let tween = Tween::new(
+            EaseMethod::Linear,
+            Duration::from_secs(1),
+            TransformPositionLens {
+                start: Vec3::ZERO,
+                end: Vec3::ONE,
+            },
+        )
+        .with_repeat_count(Duration::from_secs(3));
+        assert_eq!(
+            tween.total_duration(),
+            TotalDuration::Finite(Duration::from_secs(3))
         );
     }
 


### PR DESCRIPTION
Change the signature of `Tween::with_repeat_count()` to take an `impl Into<RepeatCount>` instead of a `RepeatCount` value, to make it easier to configure the `Tween`.

Implement for `RepeatCount`:
- `From<u32>` for an actual count, yielding `RepeatCount::Finite(value)`
- `From<Duration>` for a duration "count", yielding `RepeatCount::For(value)`