### PR TITLE
Fixed a panic in text color lens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a panic when a TextLens tried to change a section that wasn't present.
+
 ## [0.7.0] - 2023-03-09
 
 ### Added

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -398,6 +398,21 @@ mod tests {
 
         lens.lerp(&mut text, 0.3);
         assert_eq!(text.sections[0].style.color, Color::rgba(0.7, 0., 0.3, 1.0));
+
+        let mut lens_section1 = TextColorLens{
+            start: Color::RED,
+            end: Color::BLUE,
+            section: 1,
+        };
+
+        lens_section1.lerp(&mut text, 1.);
+        //Should not have changed because the lens targets section 1
+        assert_eq!(text.sections[0].style.color, Color::rgba(0.7, 0., 0.3, 1.0));
+
+        text.sections.push(TextSection { value: "".to_string(), style: Default::default() });
+
+        lens_section1.lerp(&mut text, 0.3);
+        assert_eq!(text.sections[1].style.color, Color::rgba(0.7, 0., 0.3, 1.0));
     }
 
     #[test]

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -98,7 +98,10 @@ impl Lens<Text> for TextColorLens {
         let start: Vec4 = self.start.into();
         let end: Vec4 = self.end.into();
         let value = start.lerp(end, ratio);
-        target.sections[self.section].style.color = value.into();
+
+        if let Some(section) = target.sections.get_mut(self.section){
+            section.style.color = value.into();
+        }
     }
 }
 


### PR DESCRIPTION
Hi. The `TextColorLens` can panic if the text section it's looking for isn't there. I just got it to do nothing in that case instead.