### PR TITLE
BackgroundColor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added built-in support for the `BackgroundColor` bevy component, under the `bevy_ui` feature.
+
 ## [0.8.0] - 2023-07-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The naming scheme for predefined lenses is `"<TargetName><FieldName>Lens"`, wher
 | | [`scale`](https://docs.rs/bevy/0.11.0/bevy/transform/components/struct.Transform.html#structfield.scale) | [`TransformScaleLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.TransformScaleLens.html) | |
 | [`Sprite`](https://docs.rs/bevy/0.11.0/bevy/sprite/struct.Sprite.html) | [`color`](https://docs.rs/bevy/0.11.0/bevy/sprite/struct.Sprite.html#structfield.color) | [`SpriteColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.SpriteColorLens.html) | `bevy_sprite` |
 | [`Style`](https://docs.rs/bevy/0.11.0/bevy/ui/struct.Style.html) | [`position`](https://docs.rs/bevy/0.11.0/bevy/ui/struct.Style.html#structfield.position) | [`UiPositionLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.UiPositionLens.html) | `bevy_ui` |
-| ['BackgroundColor'](https://docs.rs/bevy/0.11.0/bevy/ui/struct.BackgroundColor.html)| | [`UiBackgroundColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.UiBackgroundColorLens.html) | `bevy_ui` |
+| [`BackgroundColor`](https://docs.rs/bevy/0.11.0/bevy/ui/struct.BackgroundColor.html)| | [`UiBackgroundColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.UiBackgroundColorLens.html) | `bevy_ui` |
 | [`Text`](https://docs.rs/bevy/0.11.0/bevy/text/struct.Text.html) | [`TextStyle::color`](https://docs.rs/bevy/0.11.0/bevy/text/struct.TextStyle.html#structfield.color) | [`TextColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.TextColorLens.html) | `bevy_text` |
 
 ¹ Shortest-path interpolation between two rotations, using `Quat::slerp()`.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The naming scheme for predefined lenses is `"<TargetName><FieldName>Lens"`, wher
 | | [`scale`](https://docs.rs/bevy/0.11.0/bevy/transform/components/struct.Transform.html#structfield.scale) | [`TransformScaleLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.TransformScaleLens.html) | |
 | [`Sprite`](https://docs.rs/bevy/0.11.0/bevy/sprite/struct.Sprite.html) | [`color`](https://docs.rs/bevy/0.11.0/bevy/sprite/struct.Sprite.html#structfield.color) | [`SpriteColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.SpriteColorLens.html) | `bevy_sprite` |
 | [`Style`](https://docs.rs/bevy/0.11.0/bevy/ui/struct.Style.html) | [`position`](https://docs.rs/bevy/0.11.0/bevy/ui/struct.Style.html#structfield.position) | [`UiPositionLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.UiPositionLens.html) | `bevy_ui` |
+| ['BackgroundColor'](https://docs.rs/bevy/0.11.0/bevy/ui/struct.BackgroundColor.html)| | [`UiBackgroundColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.UiBackgroundColorLens.html) | `bevy_ui` |
 | [`Text`](https://docs.rs/bevy/0.11.0/bevy/text/struct.Text.html) | [`TextStyle::color`](https://docs.rs/bevy/0.11.0/bevy/text/struct.TextStyle.html#structfield.color) | [`TextColorLens`](https://docs.rs/bevy_tweening/latest/bevy_tweening/lens/struct.TextColorLens.html) | `bevy_text` |
 
 ¹ Shortest-path interpolation between two rotations, using `Quat::slerp()`.

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -319,6 +319,27 @@ impl Lens<Style> for UiPositionLens {
     }
 }
 
+/// Gamer
+#[cfg(feature = "bevy_ui")]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct UiBackgroundColorLens {
+    /// Start position.
+    pub start: Color,
+    /// End position.
+    pub end: Color,
+}
+
+
+#[cfg(feature = "bevy_ui")]
+impl Lens<BackgroundColor> for UiBackgroundColorLens {
+    fn lerp(&mut self, target: &mut BackgroundColor, ratio: f32) {
+        let start: Vec4 = self.start.into();
+        let end: Vec4 = self.end.into();
+        let value = start.lerp(end, ratio);
+        target.0 = value.into();
+    }
+}
+
 /// A lens to manipulate the [`color`] field of a [`ColorMaterial`] asset.
 ///
 /// [`color`]: https://docs.rs/bevy/0.11.0/bevy/sprite/struct.ColorMaterial.html#structfield.color

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -49,6 +49,11 @@ impl Plugin for TweeningPlugin {
             Update,
             component_animator_system::<Style>.in_set(AnimationSystem::AnimationUpdate),
         );
+        #[cfg(feature = "bevy_ui")]
+        app.add_systems(
+            Update,
+            component_animator_system::<BackgroundColor>.in_set(AnimationSystem::AnimationUpdate),
+        );
 
         #[cfg(feature = "bevy_sprite")]
         app.add_systems(


### PR DESCRIPTION
I's pretty common to need the ability to fade UI elements/images on and off, so I added a lens for BackgroundColor. 

Simply tween the alpha value for two Color::rgb().set_a()

```rust
let selected_color = Color::RED;
let tween_opac = Tween::new(
    EaseFunction::QuadraticIn,
    Duration::from_secs(1),
    UiBackgroundColorLens {
        start: selected_color.set_a(0.9),
        end: selected_color.set_a(0.0),
    },
);
let animator = Animator::new(tween_opac);
```
It's very nice for flashing something on screen and removing after a delay, like a killfeed notification.

```rust
let selected_color = Color::RED;
let tween_opac_in = Tween::new(
    EaseFunction::QuadraticIn,
    Duration::from_millis(500),
    UiBackgroundColorLens {
        start: selected_color.set_a(0.0),
        end: selected_color.set_a(0.9),
    },
);
let tween_opac_out = Tween::new(
    EaseFunction::QuadraticIn,
    Duration::from_secs(1),
    UiBackgroundColorLens {
        start: selected_color.set_a(0.9),
        end: selected_color.set_a(0.0),
    },
).with_completed_event(
    TweenEvents::KillNotifEnded as u64,
);
let animator =  Animator::new(tween_opac_in
    .then(Delay::new(
        Duration::from_secs(15),
    ))
    .then(tween_opac_out)
);
```


This would also work for going between any 2 colors, but I think the opacity will be most used.
