### PR TITLE
Add a tweening settings resource

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,9 +488,9 @@ impl<T: Asset> AssetAnimator<T> {
     }
 }
 
-/// Default tweening settings
+/// Tweening settings
 #[derive(Resource, Default, Clone, Copy)]
-pub struct TweenSettings {
+pub struct TweeningSettings {
     /// Default completed event user data
     /// setting this value will always fire the completed event without having to set it explicitly
     pub default_completed_event_data: Option<u64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,6 +488,14 @@ impl<T: Asset> AssetAnimator<T> {
     }
 }
 
+/// Default tweening settings
+#[derive(Resource, Default, Clone, Copy)]
+pub struct TweenSettings {
+    /// Default completed event user data
+    /// setting this value will always fire the completed event without having to set it explicitly
+    pub default_completed_event_data: Option<u64>,
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "bevy_asset")]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,7 @@ use bevy::{ecs::component::Component, prelude::*};
 
 #[cfg(feature = "bevy_asset")]
 use crate::{tweenable::AssetTarget, AssetAnimator};
-use crate::{tweenable::ComponentTarget, Animator, AnimatorState, TweenCompleted};
+use crate::{tweenable::ComponentTarget, Animator, AnimatorState, TweenCompleted, TweenSettings};
 
 /// Plugin to add systems related to tweening of common components and assets.
 ///
@@ -39,10 +39,12 @@ pub struct TweeningPlugin;
 
 impl Plugin for TweeningPlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<TweenCompleted>().add_systems(
-            Update,
-            component_animator_system::<Transform>.in_set(AnimationSystem::AnimationUpdate),
-        );
+        app.init_resource::<TweenSettings>()
+            .add_event::<TweenCompleted>()
+            .add_systems(
+                Update,
+                component_animator_system::<Transform>.in_set(AnimationSystem::AnimationUpdate),
+            );
 
         #[cfg(feature = "bevy_ui")]
         app.add_systems(
@@ -85,6 +87,7 @@ pub fn component_animator_system<T: Component>(
     time: Res<Time>,
     mut query: Query<(Entity, &mut T, &mut Animator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
+    settings: Res<TweenSettings>,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
     for (entity, target, mut animator) in query.iter_mut() {
@@ -96,6 +99,7 @@ pub fn component_animator_system<T: Component>(
                 &mut target,
                 entity,
                 &mut events,
+                &settings,
             );
         }
     }
@@ -113,6 +117,7 @@ pub fn asset_animator_system<T: Asset>(
     assets: ResMut<Assets<T>>,
     mut query: Query<(Entity, &mut AssetAnimator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
+    settings: Res<TweenSettings>,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
     let mut target = AssetTarget::new(assets);
@@ -128,6 +133,7 @@ pub fn asset_animator_system<T: Asset>(
                 &mut target,
                 entity,
                 &mut events,
+                &settings,
             );
         }
     }
@@ -222,6 +228,7 @@ mod tests {
         .with_completed_event(0);
 
         let mut env = TestEnv::new(Animator::new(tween));
+        env.world_mut().init_resource::<TweenSettings>();
 
         // After being inserted, components are always considered changed
         let transform = env.transform();

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,9 @@ use bevy::{ecs::component::Component, prelude::*};
 
 #[cfg(feature = "bevy_asset")]
 use crate::{tweenable::AssetTarget, AssetAnimator};
-use crate::{tweenable::ComponentTarget, Animator, AnimatorState, TweenCompleted, TweenSettings};
+use crate::{
+    tweenable::ComponentTarget, Animator, AnimatorState, TweenCompleted, TweeningSettings,
+};
 
 /// Plugin to add systems related to tweening of common components and assets.
 ///
@@ -39,7 +41,7 @@ pub struct TweeningPlugin;
 
 impl Plugin for TweeningPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<TweenSettings>()
+        app.init_resource::<TweeningSettings>()
             .add_event::<TweenCompleted>()
             .add_systems(
                 Update,
@@ -87,7 +89,7 @@ pub fn component_animator_system<T: Component>(
     time: Res<Time>,
     mut query: Query<(Entity, &mut T, &mut Animator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
-    settings: Res<TweenSettings>,
+    settings: Res<TweeningSettings>,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
     for (entity, target, mut animator) in query.iter_mut() {
@@ -117,7 +119,7 @@ pub fn asset_animator_system<T: Asset>(
     assets: ResMut<Assets<T>>,
     mut query: Query<(Entity, &mut AssetAnimator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
-    settings: Res<TweenSettings>,
+    settings: Res<TweeningSettings>,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
     let mut target = AssetTarget::new(assets);
@@ -228,7 +230,7 @@ mod tests {
         .with_completed_event(0);
 
         let mut env = TestEnv::new(Animator::new(tween));
-        env.world_mut().init_resource::<TweenSettings>();
+        env.world_mut().init_resource::<TweeningSettings>();
 
         // After being inserted, components are always considered changed
         let transform = env.transform();


### PR DESCRIPTION
This adds a setting to always fire the tween done event (or rather a default user data value) using a settings resource). This would of course be doable by always setting the done event user data, but if that's error-prone if the data is not used, only the event itself.

The resource is initialized in the plugin and can be replaced by inserting the resource after adding the plugin which is the idiomatic bevy approach I think. The resource init could also be skipped and the systems could use it optionally or the settings could be add to the plugin along with a new constructor, but that would be a breaking change.

If this gets merged, I'd also like to add a timescale setting to the settings resource.