### PR TITLE
Asset animator uses `Handle<T>` on same entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `AssetAnimator<T>` doesn't take any `Handle<T>` anymore; instead the `asset_animator_system::<T>()` retrieves the handle of the asset to animate from the same `Entity` the `AssetAnimator<T>` is attached to. This aligns the behavior with component animation. (#101)
+
 ### Fixed
 
 - Fixed a panic when a `TextLens` tried to change a text section that wasn't present.

--- a/examples/colormaterial_color.rs
+++ b/examples/colormaterial_color.rs
@@ -93,10 +93,10 @@ fn setup(
                 mesh: quad_mesh.clone(),
                 transform: Transform::from_translation(Vec3::new(x, y, 0.))
                     .with_scale(Vec3::splat(size)),
-                material: unique_material.clone(),
+                material: unique_material,
                 ..default()
             },
-            AssetAnimator::new(unique_material.clone(), tween),
+            AssetAnimator::new(tween),
         ));
         y -= size * spacing;
         if y < -screen_y {

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -99,7 +99,7 @@ impl Lens<Text> for TextColorLens {
         let end: Vec4 = self.end.into();
         let value = start.lerp(end, ratio);
 
-        if let Some(section) = target.sections.get_mut(self.section){
+        if let Some(section) = target.sections.get_mut(self.section) {
             section.style.color = value.into();
         }
     }
@@ -332,7 +332,6 @@ pub struct UiBackgroundColorLens {
     pub end: Color,
 }
 
-
 #[cfg(feature = "bevy_ui")]
 impl Lens<BackgroundColor> for UiBackgroundColorLens {
     fn lerp(&mut self, target: &mut BackgroundColor, ratio: f32) {
@@ -418,17 +417,20 @@ mod tests {
         lens.lerp(&mut text, 0.3);
         assert_eq!(text.sections[0].style.color, Color::rgba(0.7, 0., 0.3, 1.0));
 
-        let mut lens_section1 = TextColorLens{
+        let mut lens_section1 = TextColorLens {
             start: Color::RED,
             end: Color::BLUE,
             section: 1,
         };
 
         lens_section1.lerp(&mut text, 1.);
-        //Should not have changed because the lens targets section 1
+        // Should not have changed because the lens targets section 1
         assert_eq!(text.sections[0].style.color, Color::rgba(0.7, 0., 0.3, 1.0));
 
-        text.sections.push(TextSection { value: "".to_string(), style: Default::default() });
+        text.sections.push(TextSection {
+            value: "".to_string(),
+            style: Default::default(),
+        });
 
         lens_section1.lerp(&mut text, 0.3);
         assert_eq!(text.sections[1].style.color, Color::rgba(0.7, 0., 0.3, 1.0));

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -116,14 +116,14 @@ pub fn component_animator_system<T: Component>(
 pub fn asset_animator_system<T: Asset>(
     time: Res<Time>,
     assets: ResMut<Assets<T>>,
-    mut query: Query<(Entity, &mut AssetAnimator<T>)>,
+    mut query: Query<(Entity, &Handle<T>, &mut AssetAnimator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
     let mut target = AssetTarget::new(assets);
-    for (entity, mut animator) in query.iter_mut() {
+    for (entity, handle, mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
-            target.handle = animator.handle().clone();
+            target.handle = handle.clone();
             if !target.is_valid() {
                 continue;
             }


### PR DESCRIPTION
Change asset animation to behave like component animation, and retrieve the `Handle<T>` component referencing the asset to animate directly from a Bevy query on the same `Entity` instead of specifying it manually in the `AssetAnimator` itself.

Task: #101