### PR TITLE
Add missing docs for `trait Lens` 

### DIFF
--- a/src/lens.rs
+++ b/src/lens.rs
@@ -65,6 +65,22 @@ use bevy::prelude::*;
 ///   }
 /// }
 /// ```
+///
+/// /// Any cusotom implementation of `Lens` for animating any component or asset other than those
+/// provided by Bevy Tweening itself: `Transform`, `Sprite`, `ColorMaterial`, `Style`, `Text`,
+/// (either built-in from Bevy itself, or custom) requires manual  scheduling the appropriate
+/// system.
+///
+/// To add a system for a component `C`, use:
+///
+/// ```rust
+/// app.add_systems(Update, component_animator_system::<C>.in_set(AnimationSystem::AnimationUpdate));
+/// ```
+/// Similarly for an asset `A`, use:
+///
+///```rust
+/// app.add_systems(Update, asset_animator_system::<A>.in_set(AnimationSystem::AnimationUpdate));
+///```
 pub trait Lens<T> {
     /// Perform a linear interpolation (lerp) over the subset of fields of a
     /// component or asset the lens focuses on, based on the linear ratio


### PR DESCRIPTION
# Overview

I spent 2+ hours wondering why my implementation of Lens wasn't working for a Bevy built in component (specifically Projection as I was making a zoom in animation), only to eventually find the answer in the README instead of docs.rs.

This PR exists to save others from the same walk around of the internet & is an almost verbatim copy from the aforementioned README. 