### PR TITLE
Run a one-shot system upon completion of Tween or Delay

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -90,6 +90,7 @@ pub fn component_animator_system<T: Component>(
     time: Res<Time>,
     mut query: Query<(Entity, &mut T, &mut Animator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
+    mut commands: Commands,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
     for (entity, target, mut animator) in query.iter_mut() {
@@ -101,6 +102,7 @@ pub fn component_animator_system<T: Component>(
                 &mut target,
                 entity,
                 &mut events,
+                &mut commands,
             );
         }
     }
@@ -118,6 +120,7 @@ pub fn asset_animator_system<T: Asset>(
     assets: ResMut<Assets<T>>,
     mut query: Query<(Entity, &Handle<T>, &mut AssetAnimator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
+    mut commands: Commands,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
     let mut target = AssetTarget::new(assets);
@@ -133,6 +136,7 @@ pub fn asset_animator_system<T: Asset>(
                 &mut target,
                 entity,
                 &mut events,
+                &mut commands,
             );
         }
     }

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1338,7 +1338,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use bevy::ecs::{
-        component::Tick
+        component::Tick,
         event::Events,
         system::{CommandQueue, SystemState},
     };

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -25,6 +25,7 @@ use crate::{EaseMethod, Lens, RepeatCount, RepeatStrategy, TweeningDirection};
 /// implement [`From`]:
 /// ```no_run
 /// # use std::time::Duration;
+/// # use bevy::ecs::system::Commands;
 /// # use bevy::prelude::{Entity, Events, Mut, Transform};
 /// # use bevy_tweening::{BoxedTweenable, Sequence, Tweenable, TweenCompleted, TweenState, Targetable, TotalDuration};
 /// #
@@ -34,7 +35,7 @@ use crate::{EaseMethod, Lens, RepeatCount, RepeatStrategy, TweeningDirection};
 /// #     fn total_duration(&self) -> TotalDuration  { unimplemented!() }
 /// #     fn set_elapsed(&mut self, elapsed: Duration)  { unimplemented!() }
 /// #     fn elapsed(&self) -> Duration  { unimplemented!() }
-/// #     fn tick<'a>(&mut self, delta: Duration, target: &'a mut dyn Targetable<Transform>, entity: Entity, events: &mut Mut<Events<TweenCompleted>>) -> TweenState  { unimplemented!() }
+/// #     fn tick<'a>(&mut self, delta: Duration, target: &'a mut dyn Targetable<Transform>, entity: Entity, events: &mut Mut<Events<TweenCompleted>>, commands: &mut Commands) -> TweenState  { unimplemented!() }
 /// #     fn rewind(&mut self) { unimplemented!() }
 /// # }
 ///
@@ -590,9 +591,9 @@ impl<T> Tween<T> {
     ///
     /// ```
     /// # use bevy_tweening::{lens::*, *};
-    /// # use bevy::{ecs::event::EventReader, math::Vec3};
+    /// # use bevy::{ecs::event::EventReader, math::Vec3, ecs::world::World, ecs::system::Query, ecs::entity::Entity, ecs::query::With};
     /// # use std::time::Duration;
-    /// let world = World::new();  
+    /// let mut world = World::new();  
     /// let test_system_system_id = world.register_system(test_system);
     /// let tween = Tween::new(
     ///     // [...]
@@ -605,9 +606,9 @@ impl<T> Tween<T> {
     /// )
     /// .with_completed_system(test_system_system_id);
     ///
-    /// fn test_system(query: Query<Entity, With<Enemy>>) {
-    ///    for enemy in query.iter() {
-    ///       println!("Found an enemy!");
+    /// fn test_system(query: Query<Entity>) {
+    ///    for entity in query.iter() {
+    ///       println!("Found an entity!");
     ///    }
     /// }
     /// ```
@@ -720,8 +721,8 @@ impl<T> Tween<T> {
     /// but uses a system registered by [`register_system()`] instead of a callback.
     ///
     /// [`with_completed()`]: Tween::with_completed  
-    /// [`register_system()`]: bevy::ecs::world::World::register_system 
-    pub fn set_completed_system(&mut self, user_data: SystemId) { 
+    /// [`register_system()`]: bevy::ecs::world::World::register_system
+    pub fn set_completed_system(&mut self, user_data: SystemId) {
         self.system_id = Some(user_data);
     }
 
@@ -1163,8 +1164,9 @@ impl<T> Delay<T> {
     ///
     /// ```
     /// # use bevy_tweening::{lens::*, *};
-    /// # use bevy::{ecs::event::EventReader, math::Vec3};
+    /// # use bevy::{ecs::event::EventReader, math::Vec3, ecs::world::World, ecs::system::Query, ecs::entity::Entity};
     /// # use std::time::Duration;
+    /// let mut world = World::new();
     /// let test_system_system_id = world.register_system(test_system);
     /// let tween = Tween::new(
     ///     // [...]
@@ -1177,15 +1179,15 @@ impl<T> Delay<T> {
     /// )
     /// .with_completed_system(test_system_system_id);
     ///
-    /// fn test_system(query: Query<Entity, With<Enemy>>) {
-    ///    for enemy in query.iter() {
-    ///       println!("Found an enemy!");
+    /// fn test_system(query: Query<Entity>) {
+    ///    for entity in query.iter() {
+    ///       println!("Found an Entity!");
     ///    }
     /// }
     /// ```
     ///
     /// [`with_completed()`]: Tween::with_completed
-    /// [`register_system()`]: bevy::ecs::world::World::register_system 
+    /// [`register_system()`]: bevy::ecs::world::World::register_system
     #[must_use]
     pub fn with_completed_system(mut self, system_id: SystemId) -> Self {
         self.system_id = Some(system_id);
@@ -1261,7 +1263,7 @@ impl<T> Delay<T> {
     /// See [`with_completed_system()`] for details.
     ///
     /// [`with_completed()`]: Tween::with_completed
-    /// [`register_system()`]: bevy::ecs::world::World::register_system 
+    /// [`register_system()`]: bevy::ecs::world::World::register_system
     pub fn set_completed_system(&mut self, system_id: SystemId) {
         self.system_id = Some(system_id);
     }

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1,6 +1,6 @@
 use std::{ops::DerefMut, time::Duration};
 
-use bevy::prelude::*;
+use bevy::{ecs::system::SystemId, prelude::*};
 
 #[cfg(feature = "bevy_asset")]
 use bevy::asset::{Asset, AssetId};
@@ -315,6 +315,7 @@ pub trait Tweenable<T>: Send + Sync {
         target: &mut dyn Targetable<T>,
         entity: Entity,
         events: &mut Mut<Events<TweenCompleted>>,
+        commands: &mut Commands,
     ) -> TweenState;
 
     /// Rewind the animation to its starting state.
@@ -395,6 +396,7 @@ pub struct Tween<T> {
     lens: Box<dyn Lens<T> + Send + Sync + 'static>,
     on_completed: Option<Box<CompletedCallback<Tween<T>>>>,
     event_data: Option<u64>,
+    system_data: Option<SystemId>,
 }
 
 impl<T: 'static> Tween<T> {
@@ -459,6 +461,7 @@ impl<T> Tween<T> {
             lens: Box::new(lens),
             on_completed: None,
             event_data: None,
+            system_data: None,
         }
     }
 
@@ -535,6 +538,44 @@ impl<T> Tween<T> {
         C: Fn(Entity, &Self) + Send + Sync + 'static,
     {
         self.on_completed = Some(Box::new(callback));
+        self
+    }
+
+    /// Enable running a one-shot system upon completion.
+    ///
+    /// If enabled, the tween will run a system via a provided [`SystemId`] when the
+    /// animation completes. This is similar to the [`with_completed()`],
+    /// but uses a system registered by [`register_system()`] instead of a callback.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_tweening::{lens::*, *};
+    /// # use bevy::{ecs::event::EventReader, math::Vec3};
+    /// # use std::time::Duration;
+    /// let test_system_system_id = world.register_system(test_system);
+    /// let tween = Tween::new(
+    ///     // [...]
+    /// #    EaseFunction::QuadraticInOut,
+    /// #    Duration::from_secs(1),
+    /// #    TransformPositionLens {
+    /// #        start: Vec3::ZERO,
+    /// #        end: Vec3::new(3.5, 0., 0.),
+    /// #    },
+    /// )
+    /// .with_completed_system(test_system_system_id);
+    ///
+    /// fn test_system(query: Query<Entity, With<Enemy>>) {
+    ///    for enemy in query.iter() {
+    ///       println!("Found an enemy!");
+    ///    }
+    /// }
+    /// ```
+    ///
+    /// [`with_completed_system()`]: Tween::with_completed_system
+    #[must_use]
+    pub fn with_completed_system(mut self, user_data: SystemId) -> Self {
+        self.system_data = Some(user_data);
         self
     }
 
@@ -631,6 +672,28 @@ impl<T> Tween<T> {
     pub fn clear_completed_event(&mut self) {
         self.event_data = None;
     }
+
+    /// Enable running a one-shot system upon completion.
+    ///
+    /// If enabled, the tween will run a system via a provided [`SystemId`] when the
+    /// animation completes. This is similar to the [`with_completed()`],
+    /// but uses a system registered by [`register_system()`] instead of a callback.
+    ///
+    /// See [`with_completed_system()`] for details.
+    ///
+    /// [`set_completed_system()`]: Tween::set_completed_system
+    pub fn set_completed_system(&mut self, user_data: SystemId) {
+        self.system_data = Some(user_data);
+    }
+
+    /// Clear the system that will execute when the animation completes.
+    ///
+    /// See also [`set_completed_system()`].
+    ///
+    /// [`clear_completed_system()`]: Tween::clear_completed_system
+    pub fn clear_completed_system(&mut self) {
+        self.system_data = None;
+    }
 }
 
 impl<T> Tweenable<T> for Tween<T> {
@@ -656,6 +719,7 @@ impl<T> Tweenable<T> for Tween<T> {
         target: &mut dyn Targetable<T>,
         entity: Entity,
         events: &mut Mut<Events<TweenCompleted>>,
+        commands: &mut Commands,
     ) -> TweenState {
         if self.clock.state() == TweenState::Completed {
             return TweenState::Completed;
@@ -693,6 +757,9 @@ impl<T> Tweenable<T> for Tween<T> {
             }
             if let Some(cb) = &self.on_completed {
                 cb(entity, self);
+            }
+            if let Some(system_id) = &self.system_data {
+                commands.run_system(*system_id);
             }
         }
 
@@ -835,12 +902,13 @@ impl<T> Tweenable<T> for Sequence<T> {
         target: &mut dyn Targetable<T>,
         entity: Entity,
         events: &mut Mut<Events<TweenCompleted>>,
+        commands: &mut Commands,
     ) -> TweenState {
         self.elapsed = self.elapsed.saturating_add(delta).min(self.duration);
         while self.index < self.tweens.len() {
             let tween = &mut self.tweens[self.index];
             let tween_remaining = tween.duration() - tween.elapsed();
-            if let TweenState::Active = tween.tick(delta, target, entity, events) {
+            if let TweenState::Active = tween.tick(delta, target, entity, events, commands) {
                 return TweenState::Active;
             }
 
@@ -916,11 +984,12 @@ impl<T> Tweenable<T> for Tracks<T> {
         target: &mut dyn Targetable<T>,
         entity: Entity,
         events: &mut Mut<Events<TweenCompleted>>,
+        commands: &mut Commands,
     ) -> TweenState {
         self.elapsed = self.elapsed.saturating_add(delta).min(self.duration);
         let mut any_active = false;
         for tweenable in &mut self.tracks {
-            let state = tweenable.tick(delta, target, entity, events);
+            let state = tweenable.tick(delta, target, entity, events, commands);
             any_active = any_active || (state == TweenState::Active);
         }
         if any_active {
@@ -948,6 +1017,7 @@ pub struct Delay<T> {
     timer: Timer,
     on_completed: Option<Box<CompletedCallback<Delay<T>>>>,
     event_data: Option<u64>,
+    system_data: Option<SystemId>,
 }
 
 impl<T: 'static> Delay<T> {
@@ -972,6 +1042,7 @@ impl<T> Delay<T> {
             timer: Timer::new(duration, TimerMode::Once),
             on_completed: None,
             event_data: None,
+            system_data: None,
         }
     }
 
@@ -1044,6 +1115,44 @@ impl<T> Delay<T> {
         self
     }
 
+    /// Enable running a one-shot system upon completion.
+    ///
+    /// If enabled, the tween will run a system via a provided [`SystemId`] when the
+    /// animation completes. This is similar to the [`with_completed()`],
+    /// but uses a system registered by [`register_system()`] instead.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_tweening::{lens::*, *};
+    /// # use bevy::{ecs::event::EventReader, math::Vec3};
+    /// # use std::time::Duration;
+    /// let test_system_system_id = world.register_system(test_system);
+    /// let tween = Tween::new(
+    ///     // [...]
+    /// #    EaseFunction::QuadraticInOut,
+    /// #    Duration::from_secs(1),
+    /// #    TransformPositionLens {
+    /// #        start: Vec3::ZERO,
+    /// #        end: Vec3::new(3.5, 0., 0.),
+    /// #    },
+    /// )
+    /// .with_completed_system(test_system_system_id);
+    ///
+    /// fn test_system(query: Query<Entity, With<Enemy>>) {
+    ///    for enemy in query.iter() {
+    ///       println!("Found an enemy!");
+    ///    }
+    /// }
+    /// ```
+    ///
+    /// [`with_completed_system()`]: Tween::with_completed_system
+    #[must_use]
+    pub fn with_completed_system(mut self, user_data: SystemId) -> Self {
+        self.system_data = Some(user_data);
+        self
+    }
+
     /// Check if the delay completed.
     pub fn is_completed(&self) -> bool {
         self.timer.finished()
@@ -1103,6 +1212,28 @@ impl<T> Delay<T> {
     pub fn clear_completed_event(&mut self) {
         self.event_data = None;
     }
+
+    /// Enable running a one-shot system upon completion.
+    ///
+    /// If enabled, the tween will run a system via a provided [`SystemId`] when the
+    /// animation completes. This is similar to the [`with_completed()`],
+    /// but uses a system registered by [`register_system()`] instead of a callback.
+    ///
+    /// See [`with_completed_system()`] for details.
+    ///
+    /// [`set_completed_system()`]: Tween::set_completed_system
+    pub fn set_completed_system(&mut self, user_data: SystemId) {
+        self.system_data = Some(user_data);
+    }
+
+    /// Clear the system that will execute when the animation completes.
+    ///
+    /// See also [`set_completed_system()`].
+    ///
+    /// [`clear_completed_system()`]: Tween::clear_completed_system
+    pub fn clear_completed_system(&mut self) {
+        self.system_data = None;
+    }
 }
 
 impl<T> Tweenable<T> for Delay<T> {
@@ -1132,6 +1263,7 @@ impl<T> Tweenable<T> for Delay<T> {
         _target: &mut dyn Targetable<T>,
         entity: Entity,
         events: &mut Mut<Events<TweenCompleted>>,
+        commands: &mut Commands,
     ) -> TweenState {
         let was_completed = self.is_completed();
 
@@ -1150,6 +1282,9 @@ impl<T> Tweenable<T> for Delay<T> {
             if let Some(cb) = &self.on_completed {
                 cb(entity, self);
             }
+            if let Some(system_id) = &self.system_data {
+                commands.run_system(*system_id);
+            }
         }
 
         state
@@ -1167,7 +1302,10 @@ mod tests {
         time::Duration,
     };
 
-    use bevy::ecs::{event::Events, system::SystemState};
+    use bevy::ecs::{
+        event::Events,
+        system::{CommandQueue, SystemState},
+    };
 
     use super::*;
     use crate::{lens::*, test_utils::*};
@@ -1191,12 +1329,16 @@ mod tests {
     }
 
     /// Utility to create a test environment to tick a tween.
-    fn make_test_env() -> (World, Entity) {
+    fn make_test_env() -> (World, Entity, SystemId) {
         let mut world = World::new();
         world.init_resource::<Events<TweenCompleted>>();
         let entity = world.spawn(Transform::default()).id();
-        (world, entity)
+        let system_id = world.register_system(oneshot_test);
+        (world, entity, system_id)
     }
+
+    /// one-shot system to be used for testing
+    fn oneshot_test() {}
 
     /// Manually tick a test tweenable targeting a component.
     fn manual_tick_component<T: Component>(
@@ -1209,7 +1351,16 @@ mod tests {
             |world: &mut World, mut events: Mut<Events<TweenCompleted>>| {
                 let transform = world.get_mut::<T>(entity).unwrap();
                 let mut target = ComponentTarget::new(transform);
-                tween.tick(duration, &mut target, entity, &mut events)
+                // let command_queue = &mut CommandQueue::default(); // todo
+                // let mut asd = Commands::new(command_queue, world);
+                tween.tick(
+                    duration,
+                    &mut target,
+                    entity,
+                    &mut events,
+                    // passing dummy values to let things compile
+                    &mut Commands::new(&mut CommandQueue::default(), &World::default()),
+                )
             },
         )
     }
@@ -1300,7 +1451,7 @@ mod tests {
                 assert!(tween.on_completed.is_none());
                 assert!(tween.event_data.is_none());
 
-                let (mut world, entity) = make_test_env();
+                let (mut world, entity, system_id) = make_test_env();
                 let mut event_reader_system_state: SystemState<EventReader<TweenCompleted>> =
                     SystemState::new(&mut world);
 
@@ -1323,6 +1474,11 @@ mod tests {
                 tween.set_completed_event(USER_DATA);
                 assert!(tween.event_data.is_some());
                 assert_eq!(tween.event_data.unwrap(), USER_DATA);
+
+                // Activate oneshot system
+                tween.set_completed_system(system_id);
+                assert!(tween.system_data.is_some());
+                assert_eq!(tween.system_data.unwrap(), system_id);
 
                 // Loop over 2.2 seconds, so greater than one ping-pong loop
                 let tick_duration = Duration::from_millis(200);
@@ -1506,6 +1662,10 @@ mod tests {
                 // Clear event sending
                 tween.clear_completed_event();
                 assert!(tween.event_data.is_none());
+
+                // Clear oneshot system
+                tween.clear_completed_system();
+                assert!(tween.system_data.is_none());
             }
         }
     }
@@ -1537,7 +1697,7 @@ mod tests {
         // progress is independent of direction
         assert_approx_eq!(tween.progress(), 0.3);
 
-        let (mut world, entity) = make_test_env();
+        let (mut world, entity, _system_id) = make_test_env();
 
         // Progress always increases alongside the current direction
         tween.set_direction(TweeningDirection::Backward);
@@ -1592,7 +1752,7 @@ mod tests {
         );
         let mut seq = tween1.then(tween2);
 
-        let (mut world, entity) = make_test_env();
+        let (mut world, entity, _system_id) = make_test_env();
 
         for i in 1..=16 {
             let state =
@@ -1634,7 +1794,7 @@ mod tests {
             .with_repeat_count(RepeatCount::Finite(1))
         }));
 
-        let (mut world, entity) = make_test_env();
+        let (mut world, entity, _system_id) = make_test_env();
 
         // Tick halfway through the first tween, then in one tick:
         // - Finish the first tween
@@ -1746,7 +1906,7 @@ mod tests {
         let mut tracks = Tracks::new([tween1, tween2]);
         assert_eq!(tracks.duration(), Duration::from_secs(1)); // max(1., 0.8)
 
-        let (mut world, entity) = make_test_env();
+        let (mut world, entity, _system_id) = make_test_env();
 
         for i in 1..=6 {
             let state =
@@ -1815,12 +1975,19 @@ mod tests {
     #[test]
     fn delay_tick() {
         let duration = Duration::from_secs(1);
+        // Dummy world and registered oneshot system ID
+        let (mut world, entity, system_id) = make_test_env();
 
         const USER_DATA: u64 = 42;
-        let mut delay = Delay::new(duration).with_completed_event(USER_DATA);
+        let mut delay = Delay::new(duration)
+            .with_completed_event(USER_DATA)
+            .with_completed_system(system_id);
 
         assert!(delay.event_data.is_some());
         assert_eq!(delay.event_data.unwrap(), USER_DATA);
+
+        assert!(delay.system_data.is_some());
+        assert_eq!(delay.system_data.unwrap(), system_id);
 
         delay.clear_completed_event();
         assert!(delay.event_data.is_none());
@@ -1829,6 +1996,13 @@ mod tests {
         assert!(delay.event_data.is_some());
         assert_eq!(delay.event_data.unwrap(), USER_DATA);
 
+        delay.clear_completed_system();
+        assert!(delay.system_data.is_none());
+
+        delay.set_completed_system(system_id);
+        assert!(delay.system_data.is_some());
+        assert_eq!(delay.system_data.unwrap(), system_id);
+
         {
             let tweenable: &dyn Tweenable<Transform> = &delay;
             assert_eq!(tweenable.duration(), duration);
@@ -1836,8 +2010,7 @@ mod tests {
             assert_eq!(tweenable.elapsed(), Duration::ZERO);
         }
 
-        // Dummy world and event writer
-        let (mut world, entity) = make_test_env();
+        // Dummy event writer
         let mut event_reader_system_state: SystemState<EventReader<TweenCompleted>> =
             SystemState::new(&mut world);
 
@@ -1972,7 +2145,7 @@ mod tests {
 
         assert_approx_eq!(tween.progress(), 0.);
 
-        let (mut world, entity) = make_test_env();
+        let (mut world, entity, _system_id) = make_test_env();
 
         // 10%
         let state =
@@ -2019,7 +2192,7 @@ mod tests {
 
         assert_approx_eq!(tween.progress(), 0.);
 
-        let (mut world, entity) = make_test_env();
+        let (mut world, entity, _system_id) = make_test_env();
 
         // 10%
         let state =


### PR DESCRIPTION
This PR adds with_completed_system() and other related methods to allow the user to run a one-shot system when an animation or delay completes. 

The main reason why I wanted to add this is to avoid polling for a single non-repeating event; using one-shot systems can be cleaner sometimes. But there are other use-cases like chaining actions or even other animations that cant be chained normally due to limitations in the library. In those cases you may think to use callbacks, but they don't allow you to easily interact with the world, which makes one-shot systems a necessity.