### PR TITLE
Update to bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ bevy_ui = ["bevy/bevy_ui", "bevy/bevy_render"]
 bevy_text = ["bevy/bevy_text", "bevy/bevy_render", "bevy/bevy_sprite"]
 
 [dependencies]
-interpolation = "0.2"
-bevy = { version = "0.12", default-features = false }
+interpolation = "0.3"
+bevy = { version = "0.13", default-features = false }
 
 [dev-dependencies]
-bevy-inspector-egui = "0.21"
+bevy-inspector-egui = "0.23"
 
 [[example]]
 name = "menu"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -14,11 +14,11 @@ include = ["assets", "thirdparty"]
 exclude = ["examples/*.gif"]
 
 [dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 bevy_tweening = { path = "../" }
 
 [dependencies.bevy]
-version = "0.12"
+version = "0.13"
 default-features = false
 features = ["bevy_render", "bevy_sprite", "bevy_text", "bevy_ui"]
 

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -37,6 +37,8 @@
 
 use bevy::prelude::*;
 
+use crate::Lerper;
+
 /// A lens over a subset of a component.
 ///
 /// The lens takes a `target` component or asset from a query, as a mutable
@@ -95,12 +97,10 @@ impl Lens<Text> for TextColorLens {
     fn lerp(&mut self, target: &mut Text, ratio: f32) {
         // Note: Add<f32> for Color affects alpha, but not Mul<f32>. So use Vec4 for
         // consistency.
-        let start: Vec4 = self.start.into();
-        let end: Vec4 = self.end.into();
-        let value = start.lerp(end, ratio);
+        let value = self.start.lerp(&self.end, ratio);
 
         if let Some(section) = target.sections.get_mut(self.section) {
-            section.style.color = value.into();
+            section.style.color = value;
         }
     }
 }
@@ -335,10 +335,8 @@ pub struct UiBackgroundColorLens {
 #[cfg(feature = "bevy_ui")]
 impl Lens<BackgroundColor> for UiBackgroundColorLens {
     fn lerp(&mut self, target: &mut BackgroundColor, ratio: f32) {
-        let start: Vec4 = self.start.into();
-        let end: Vec4 = self.end.into();
-        let value = start.lerp(end, ratio);
-        target.0 = value.into();
+        let value = self.start.lerp(&self.end, ratio);
+        target.0 = value;
     }
 }
 
@@ -360,10 +358,8 @@ impl Lens<ColorMaterial> for ColorMaterialColorLens {
     fn lerp(&mut self, target: &mut ColorMaterial, ratio: f32) {
         // Note: Add<f32> for Color affects alpha, but not Mul<f32>. So use Vec4 for
         // consistency.
-        let start: Vec4 = self.start.into();
-        let end: Vec4 = self.end.into();
-        let value = start.lerp(end, ratio);
-        target.color = value.into();
+        let value = self.start.lerp(&self.end, ratio);
+        target.color = value;
     }
 }
 
@@ -385,10 +381,8 @@ impl Lens<Sprite> for SpriteColorLens {
     fn lerp(&mut self, target: &mut Sprite, ratio: f32) {
         // Note: Add<f32> for Color affects alpha, but not Mul<f32>. So use Vec4 for
         // consistency.
-        let start: Vec4 = self.start.into();
-        let end: Vec4 = self.end.into();
-        let value = start.lerp(end, ratio);
-        target.color = value.into();
+        let value = self.start.lerp(&self.end, ratio);
+        target.color = value;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -539,11 +539,22 @@ impl<T: Asset> AssetAnimator<T> {
     animator_impl!();
 }
 
+trait Lerper {
+    fn lerp(&self, target: &Self, ratio: f32) -> Self;
+}
+
+impl Lerper for Color {
+    fn lerp(&self, target: &Color, ratio: f32) -> Color {
+        let r = self.r().lerp(target.r(), ratio);
+        let g = self.g().lerp(target.g(), ratio);
+        let b = self.b().lerp(target.b(), ratio);
+        let a = self.a().lerp(target.a(), ratio);
+        Color::rgba(r, g, b, a)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "bevy_asset")]
-    use bevy::reflect::TypeUuid;
-
     use super::*;
     use crate::test_utils::*;
 
@@ -558,15 +569,14 @@ mod tests {
     }
 
     #[cfg(feature = "bevy_asset")]
-    #[derive(Asset, Debug, Default, Reflect, TypeUuid)]
-    #[uuid = "a33abc11-264e-4bbb-82e8-b87226bb4383"]
+    #[derive(Asset, Debug, Default, Reflect)]
     struct DummyAsset {
         value: f32,
     }
 
     impl Lens<DummyComponent> for DummyLens {
         fn lerp(&mut self, target: &mut DummyComponent, ratio: f32) {
-            target.value = self.start.lerp(&self.end, &ratio);
+            target.value = self.start.lerp(self.end, ratio);
         }
     }
 
@@ -583,7 +593,7 @@ mod tests {
     #[cfg(feature = "bevy_asset")]
     impl Lens<DummyAsset> for DummyLens {
         fn lerp(&mut self, target: &mut DummyAsset, ratio: f32) {
-            target.value = self.start.lerp(&self.end, &ratio);
+            target.value = self.start.lerp(self.end, ratio);
         }
     }
 

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -486,7 +486,7 @@ impl<T> Tween<T> {
     /// .with_completed_event(42);
     ///
     /// fn my_system(mut reader: EventReader<TweenCompleted>) {
-    ///   for ev in reader.iter() {
+    ///   for ev in reader.read() {
     ///     assert_eq!(ev.user_data, 42);
     ///     println!("Entity {:?} raised TweenCompleted!", ev.entity);
     ///   }
@@ -991,7 +991,7 @@ impl<T> Delay<T> {
     ///   .with_completed_event(42);
     ///
     /// fn my_system(mut reader: EventReader<TweenCompleted>) {
-    ///   for ev in reader.iter() {
+    ///   for ev in reader.read() {
     ///     assert_eq!(ev.user_data, 42);
     ///     println!("Entity {:?} raised TweenCompleted!", ev.entity);
     ///   }


### PR DESCRIPTION
This updates dependecies to bevy 0.13.

Added a private trait to lerp colors, to fix the missing conversion between Color and Vec4.