### PR TITLE
Enable lenses to avoid change detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `Lens::lerp()` now takes a `&mut dyn Targetable<T>` instead of `&mut T`.
+  This ensures the lens can skip change detection if needed.
+  `Targetable<T>` conceptually acts like a `Mut<T>`, but allows encapsulating assets too.
+  There should be no other change than the function signature to upgrade custom lenses,
+  because `dyn Targetable<T>` now implements `Defer` and `DeferMut`, so can be used in place of `&mut T`.
+- `AssetTarget::new()` now takes a simple `Mut<Assets<T>>` instead of `ResMut<Assets<T>>`.
+
+### Fixed
+
+- Fixed change detection such that lenses which do not dereference their target
+  do not unconditionally mark that target (component or asset) as changed from the point of view of ECS. (#91)
+
+### Added
+
+- Added `Targetable::target(&self) -> &T`.
+- `dyn Targetable<T>` now implements `Defer` and `DeferMut`, so can be used in place of `&T` and `&mut T`.
+- Added `ComponentTarget::to_mut(&mut self) -> Mut<'_, T>` to "reborrow" the component target as a `Mut<T>`.
+
 ## [0.10.0] - 2024-02-27
 
 ### Changed

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -348,7 +348,7 @@ impl Lens<BackgroundColor> for UiBackgroundColorLens {
 ///
 /// [`color`]: https://docs.rs/bevy/0.12.0/bevy/sprite/struct.ColorMaterial.html#structfield.color
 /// [`ColorMaterial`]: https://docs.rs/bevy/0.12.0/bevy/sprite/struct.ColorMaterial.html
-#[cfg(feature = "bevy_sprite")]
+#[cfg(all(feature = "bevy_sprite", feature = "bevy_asset"))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ColorMaterialColorLens {
     /// Start color.
@@ -357,7 +357,7 @@ pub struct ColorMaterialColorLens {
     pub end: Color,
 }
 
-#[cfg(feature = "bevy_sprite")]
+#[cfg(all(feature = "bevy_sprite", feature = "bevy_asset"))]
 impl Lens<ColorMaterial> for ColorMaterialColorLens {
     fn lerp(&mut self, target: &mut dyn Targetable<ColorMaterial>, ratio: f32) {
         use crate::ColorLerper as _;
@@ -401,7 +401,10 @@ mod tests {
 
     use super::*;
 
-    use crate::tweenable::{AssetTarget, ComponentTarget};
+    use crate::tweenable::ComponentTarget;
+
+    #[cfg(all(feature = "bevy_sprite", feature = "bevy_asset"))]
+    use crate::tweenable::AssetTarget;
 
     #[cfg(feature = "bevy_text")]
     #[test]
@@ -989,7 +992,7 @@ mod tests {
         assert_eq!(style.bottom, Val::Percent(31.));
     }
 
-    #[cfg(feature = "bevy_sprite")]
+    #[cfg(all(feature = "bevy_sprite", feature = "bevy_asset"))]
     #[test]
     fn colormaterial_color() {
         let mut lens = ColorMaterialColorLens {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,11 +540,13 @@ impl<T: Asset> AssetAnimator<T> {
 /// Trait to interpolate between two values.
 /// Needed for color.
 #[allow(dead_code)]
+#[cfg(any(feature = "bevy_sprite", feature = "bevy_ui", feature = "bevy_text"))]
 trait ColorLerper {
     fn lerp(&self, target: &Self, ratio: f32) -> Self;
 }
 
 #[allow(dead_code)]
+#[cfg(any(feature = "bevy_sprite", feature = "bevy_ui", feature = "bevy_text"))]
 impl ColorLerper for Color {
     fn lerp(&self, target: &Color, ratio: f32) -> Color {
         let r = self.r().lerp(target.r(), ratio);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,10 @@ impl ColorLerper for Color {
 
 #[cfg(test)]
 mod tests {
+    use bevy::ecs::component::Tick;
+
+    use self::tweenable::ComponentTarget;
+
     use super::*;
     use crate::test_utils::*;
 
@@ -565,7 +569,7 @@ mod tests {
         end: f32,
     }
 
-    #[derive(Debug, Default, Component)]
+    #[derive(Debug, Default, Clone, Copy, Component)]
     struct DummyComponent {
         value: f32,
     }
@@ -577,7 +581,7 @@ mod tests {
     }
 
     impl Lens<DummyComponent> for DummyLens {
-        fn lerp(&mut self, target: &mut DummyComponent, ratio: f32) {
+        fn lerp(&mut self, target: &mut dyn Targetable<DummyComponent>, ratio: f32) {
             target.value = self.start.lerp(self.end, ratio);
         }
     }
@@ -587,14 +591,29 @@ mod tests {
         let mut c = DummyComponent::default();
         let mut l = DummyLens { start: 0., end: 1. };
         for r in [0_f32, 0.01, 0.3, 0.5, 0.9, 0.999, 1.] {
-            l.lerp(&mut c, r);
+            {
+                let mut added = Tick::new(0);
+                let mut last_changed = Tick::new(0);
+                let mut target = ComponentTarget::new(Mut::new(
+                    &mut c,
+                    &mut added,
+                    &mut last_changed,
+                    Tick::new(0),
+                    Tick::new(1),
+                ));
+
+                l.lerp(&mut target, r);
+
+                assert!(target.to_mut().is_changed());
+            }
+
             assert_approx_eq!(c.value, r);
         }
     }
 
     #[cfg(feature = "bevy_asset")]
     impl Lens<DummyAsset> for DummyLens {
-        fn lerp(&mut self, target: &mut DummyAsset, ratio: f32) {
+        fn lerp(&mut self, target: &mut dyn Targetable<DummyAsset>, ratio: f32) {
             target.value = self.start.lerp(self.end, ratio);
         }
     }
@@ -602,11 +621,28 @@ mod tests {
     #[cfg(feature = "bevy_asset")]
     #[test]
     fn dummy_lens_asset() {
-        let mut a = DummyAsset::default();
+        use self::tweenable::AssetTarget;
+
+        let mut assets = Assets::<DummyAsset>::default();
+        let handle = assets.add(DummyAsset::default());
+
         let mut l = DummyLens { start: 0., end: 1. };
         for r in [0_f32, 0.01, 0.3, 0.5, 0.9, 0.999, 1.] {
-            l.lerp(&mut a, r);
-            assert_approx_eq!(a.value, r);
+            {
+                let mut added = Tick::new(0);
+                let mut last_changed = Tick::new(0);
+                let mut target = AssetTarget::new(Mut::new(
+                    &mut assets,
+                    &mut added,
+                    &mut last_changed,
+                    Tick::new(0),
+                    Tick::new(0),
+                ));
+                target.handle = handle.clone();
+
+                l.lerp(&mut target, r);
+            }
+            assert_approx_eq!(assets.get(handle.clone()).unwrap().value, r);
         }
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -113,12 +113,12 @@ pub fn component_animator_system<T: Component>(
 #[cfg(feature = "bevy_asset")]
 pub fn asset_animator_system<T: Asset>(
     time: Res<Time>,
-    assets: ResMut<Assets<T>>,
+    mut assets: ResMut<Assets<T>>,
     mut query: Query<(Entity, &Handle<T>, &mut AssetAnimator<T>)>,
     events: ResMut<Events<TweenCompleted>>,
 ) {
     let mut events: Mut<Events<TweenCompleted>> = events.into();
-    let mut target = AssetTarget::new(assets);
+    let mut target = AssetTarget::new(assets.reborrow());
     for (entity, handle, mut animator) in query.iter_mut() {
         if animator.state != AnimatorState::Paused {
             target.handle = handle.clone();
@@ -138,28 +138,44 @@ pub fn asset_animator_system<T: Asset>(
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        marker::PhantomData,
+        ops::DerefMut,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
+
     use crate::{lens::TransformPositionLens, *};
 
     /// A simple isolated test environment with a [`World`] and a single
     /// [`Entity`] in it.
-    struct TestEnv {
+    struct TestEnv<T: Component> {
         world: World,
         entity: Entity,
+        _phantom: PhantomData<T>,
     }
 
-    impl TestEnv {
+    impl<T: Component + Default> TestEnv<T> {
         /// Create a new test environment containing a single entity with a
         /// [`Transform`], and add the given animator on that same entity.
-        pub fn new<T: Component>(animator: T) -> Self {
+        pub fn new(animator: Animator<T>) -> Self {
             let mut world = World::new();
             world.init_resource::<Events<TweenCompleted>>();
             world.init_resource::<Time>();
 
-            let entity = world.spawn((Transform::default(), animator)).id();
+            let entity = world.spawn((T::default(), animator)).id();
 
-            Self { world, entity }
+            Self {
+                world,
+                entity,
+                _phantom: PhantomData,
+            }
         }
+    }
 
+    impl<T: Component> TestEnv<T> {
         /// Get the test world.
         pub fn world_mut(&mut self) -> &mut World {
             &mut self.world
@@ -176,7 +192,7 @@ mod tests {
 
             // Reset world-related change detection
             self.world.clear_trackers();
-            assert!(!self.transform().is_changed());
+            assert!(!self.component_mut().is_changed());
 
             // Tick system
             system.run((), &mut self.world);
@@ -186,17 +202,14 @@ mod tests {
             events.update();
         }
 
-        /// Get the animator for the transform.
-        pub fn animator(&self) -> &Animator<Transform> {
-            self.world
-                .entity(self.entity)
-                .get::<Animator<Transform>>()
-                .unwrap()
+        /// Get the animator for the component.
+        pub fn animator(&self) -> &Animator<T> {
+            self.world.entity(self.entity).get::<Animator<T>>().unwrap()
         }
 
-        /// Get the transform component.
-        pub fn transform(&mut self) -> Mut<Transform> {
-            self.world.get_mut::<Transform>(self.entity).unwrap()
+        /// Get the component.
+        pub fn component_mut(&mut self) -> Mut<T> {
+            self.world.get_mut::<T>(self.entity).unwrap()
         }
 
         /// Get the emitted event count since last tick.
@@ -221,7 +234,7 @@ mod tests {
         let mut env = TestEnv::new(Animator::new(tween));
 
         // After being inserted, components are always considered changed
-        let transform = env.transform();
+        let transform = env.component_mut();
         assert!(transform.is_changed());
 
         // fn nit() {}
@@ -234,7 +247,7 @@ mod tests {
         let animator = env.animator();
         assert_eq!(animator.state, AnimatorState::Playing);
         assert_eq!(animator.tweenable().times_completed(), 0);
-        let transform = env.transform();
+        let transform = env.component_mut();
         assert!(transform.is_changed());
         assert!(transform.translation.abs_diff_eq(Vec3::ZERO, 1e-5));
 
@@ -244,7 +257,7 @@ mod tests {
         let animator = env.animator();
         assert_eq!(animator.state, AnimatorState::Playing);
         assert_eq!(animator.tweenable().times_completed(), 0);
-        let transform = env.transform();
+        let transform = env.component_mut();
         assert!(transform.is_changed());
         assert!(transform.translation.abs_diff_eq(Vec3::splat(0.5), 1e-5));
 
@@ -254,7 +267,7 @@ mod tests {
         let animator = env.animator();
         assert_eq!(animator.state, AnimatorState::Playing);
         assert_eq!(animator.tweenable().times_completed(), 1);
-        let transform = env.transform();
+        let transform = env.component_mut();
         assert!(transform.is_changed());
         assert!(transform.translation.abs_diff_eq(Vec3::ONE, 1e-5));
 
@@ -264,8 +277,109 @@ mod tests {
         let animator = env.animator();
         assert_eq!(animator.state, AnimatorState::Playing);
         assert_eq!(animator.tweenable().times_completed(), 1);
-        let transform = env.transform();
+        let transform = env.component_mut();
         assert!(!transform.is_changed());
         assert!(transform.translation.abs_diff_eq(Vec3::ONE, 1e-5));
+    }
+
+    #[derive(Debug, Default, Clone, Copy, Component)]
+    struct DummyComponent {
+        value: f32,
+    }
+
+    /// Test [`Lens`] which only access mutably the target component if `defer`
+    /// is `true`.
+    struct ConditionalDeferLens {
+        pub defer: Arc<AtomicBool>,
+    }
+
+    impl Lens<DummyComponent> for ConditionalDeferLens {
+        fn lerp(&mut self, target: &mut dyn Targetable<DummyComponent>, ratio: f32) {
+            if self.defer.load(Ordering::SeqCst) {
+                target.deref_mut().value += ratio;
+            }
+        }
+    }
+
+    #[test]
+    fn change_detect_component_conditional() {
+        let defer = Arc::new(AtomicBool::new(false));
+        let tween = Tween::new(
+            EaseMethod::Linear,
+            Duration::from_secs(1),
+            ConditionalDeferLens {
+                defer: Arc::clone(&defer),
+            },
+        )
+        .with_completed_event(0);
+
+        let mut env = TestEnv::new(Animator::new(tween));
+
+        // After being inserted, components are always considered changed
+        let component = env.component_mut();
+        assert!(component.is_changed());
+
+        let mut system = IntoSystem::into_system(component_animator_system::<DummyComponent>);
+        system.initialize(env.world_mut());
+
+        assert!(!defer.load(Ordering::SeqCst));
+
+        // Mutation disabled
+        env.tick(Duration::ZERO, &mut system);
+
+        let animator = env.animator();
+        assert_eq!(animator.state, AnimatorState::Playing);
+        assert_eq!(animator.tweenable().times_completed(), 0);
+        let component = env.component_mut();
+        assert!(!component.is_changed());
+        assert!((component.value - 0.).abs() <= 1e-5);
+
+        // Zero-length tick should not change the component
+        env.tick(Duration::from_millis(0), &mut system);
+
+        let animator = env.animator();
+        assert_eq!(animator.state, AnimatorState::Playing);
+        assert_eq!(animator.tweenable().times_completed(), 0);
+        let component = env.component_mut();
+        assert!(!component.is_changed());
+        assert!((component.value - 0.).abs() <= 1e-5);
+
+        // New tick, but lens mutation still disabled
+        env.tick(Duration::from_millis(200), &mut system);
+
+        let animator = env.animator();
+        assert_eq!(animator.state, AnimatorState::Playing);
+        assert_eq!(animator.tweenable().times_completed(), 0);
+        let component = env.component_mut();
+        assert!(!component.is_changed());
+        assert!((component.value - 0.).abs() <= 1e-5);
+
+        // Enable lens mutation
+        defer.store(true, Ordering::SeqCst);
+
+        // The current time is already at t=0.2s, so even if we don't increment it, for
+        // a tween duration of 1s the ratio is t=0.2, so the lens will actually
+        // increment the component's value.
+        env.tick(Duration::from_millis(0), &mut system);
+
+        let animator = env.animator();
+        assert_eq!(animator.state, AnimatorState::Playing);
+        assert_eq!(animator.tweenable().times_completed(), 0);
+        let component = env.component_mut();
+        assert!(component.is_changed());
+        assert!((component.value - 0.2).abs() <= 1e-5);
+
+        // 0.2s + 0.3s = 0.5s
+        // t = 0.5s / 1s = 0.5
+        // value += 0.5
+        // value == 0.7
+        env.tick(Duration::from_millis(300), &mut system);
+
+        let animator = env.animator();
+        assert_eq!(animator.state, AnimatorState::Playing);
+        assert_eq!(animator.tweenable().times_completed(), 0);
+        let component = env.component_mut();
+        assert!(component.is_changed());
+        assert!((component.value - 0.7).abs() <= 1e-5);
     }
 }


### PR DESCRIPTION
Add the ability for all `Lens`es to avoid triggering change detection if they don't make any actual change to their target (component or asset).

This change modifies the signature of `Lerp::lerp()` to take `&mut dyn Targetable<T>` instead of `&mut T`. The `Targetable<T>` acts as a `Mut<T>`, marking the target as changed only if actually dereferenced mutably.

Note that we cannot use `Mut<T>` directly because we can't obtain a `Mut<A: Asset>` without marking the asset as mutable; see bevyengine/bevy#13104.

Fixes #91