### PR TITLE
Trigger observers when TweenCompleted event is sent

### DIFF
--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -801,7 +801,7 @@ impl<T> Tweenable<T> for Tween<T> {
 
 
                 // trigger all entity-scoped observers
-                commands.trigger_targets(event, [entity]);
+                commands.trigger_targets(event, entity);
             }
             if let Some(cb) = &self.on_completed {
                 cb(entity, self);

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1336,11 +1336,8 @@ impl<T> Tweenable<T> for Delay<T> {
                 // send regular event
                 events.send(event);
 
-                // trigger all global observers
-                commands.trigger(event);
-
                 // trigger all entity-scoped observers
-                commands.trigger_targets(event, [entity]);
+                commands.trigger_targets(event, entity);
             }
             if let Some(cb) = &self.on_completed {
                 cb(entity, self);

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -791,10 +791,19 @@ impl<T> Tweenable<T> for Tween<T> {
         // If completed at least once this frame, notify the user
         if times_completed > 0 {
             if let Some(user_data) = &self.event_data {
-                events.send(TweenCompleted {
+                let event = TweenCompleted {
                     entity,
                     user_data: *user_data,
-                });
+                };
+
+                // send regular event
+                events.send(event);
+
+                // trigger all global observers
+                commands.trigger(event);
+
+                // trigger all entity-scoped observers
+                commands.trigger_targets(event, [entity]);
             }
             if let Some(cb) = &self.on_completed {
                 cb(entity, self);
@@ -1321,10 +1330,19 @@ impl<T> Tweenable<T> for Delay<T> {
         // If completed this frame, notify the user
         if (state == TweenState::Completed) && !was_completed {
             if let Some(user_data) = &self.event_data {
-                events.send(TweenCompleted {
+                let event = TweenCompleted {
                     entity,
                     user_data: *user_data,
-                });
+                };
+
+                // send regular event
+                events.send(event);
+
+                // trigger all global observers
+                commands.trigger(event);
+
+                // trigger all entity-scoped observers
+                commands.trigger_targets(event, [entity]);
             }
             if let Some(cb) = &self.on_completed {
                 cb(entity, self);

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -799,8 +799,6 @@ impl<T> Tweenable<T> for Tween<T> {
                 // send regular event
                 events.send(event);
 
-                // trigger all global observers
-                commands.trigger(event);
 
                 // trigger all entity-scoped observers
                 commands.trigger_targets(event, [entity]);

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -799,7 +799,6 @@ impl<T> Tweenable<T> for Tween<T> {
                 // send regular event
                 events.send(event);
 
-
                 // trigger all entity-scoped observers
                 commands.trigger_targets(event, entity);
             }


### PR DESCRIPTION
This PR is very simple: trigger observers when the TweenCompleted event gets sent out. I added this right next to event.send() so it will always happen if use "with_completed_event".

However, we may want to add an equivalent to "with_completed_event" so its opt-in, i.e. "with_completed_trigger" and "with_completed_trigger_targets".

For now, this is the easiest solution to get the ball rolling on this. 
