### PR TITLE
update to bevy 0.16-rc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,11 @@ bevy_ui = ["bevy/bevy_ui", "bevy/bevy_render"]
 bevy_text = ["bevy/bevy_text", "bevy/bevy_render", "bevy/bevy_sprite"]
 
 [dependencies]
+bevy = { version = "0.16", default-features = false, features = [ "bevy_color",]}
 
-# Note: need 'x11' or 'wayland' on Linux for winit to build
-# Note: abuse 'bevy_color' to force 'bevy_math/curve' feature, which defines EaseFunction
-# TODO: need 'std' or libm' for math library and transform, but it needs to be options too, feature?
-bevy = { version = "0.16.0-rc", default-features = false, features = ["std", "x11", "bevy_color",]}
-#
 
 [dev-dependencies]
-# TODO: replace with released version
-bevy-inspector-egui = { git = "https://github.com/slyedoc/bevy-inspector-egui", branch = "bevy_0.16" }
+bevy-inspector-egui = { version = "0.31" }
 
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,44 +27,49 @@ bevy_ui = ["bevy/bevy_ui", "bevy/bevy_render"]
 bevy_text = ["bevy/bevy_text", "bevy/bevy_render", "bevy/bevy_sprite"]
 
 [dependencies]
+
 # Note: need 'x11' or 'wayland' on Linux for winit to build
 # Note: abuse 'bevy_color' to force 'bevy_math/curve' feature, which defines EaseFunction
-bevy = { version = "0.15", default-features = false, features = ["x11", "bevy_color"] }
+# TODO: need 'std' or libm' for math library and transform, but it needs to be options too, feature?
+bevy = { version = "0.16.0-rc", default-features = false, features = ["std", "x11", "bevy_color",]}
+#
 
 [dev-dependencies]
-bevy-inspector-egui = "0.28"
+# TODO: replace with released version
+bevy-inspector-egui = { git = "https://github.com/slyedoc/bevy-inspector-egui", branch = "bevy_0.16" }
+
 
 [[example]]
 name = "menu"
-required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit"]
+required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "colormaterial_color"
-required-features = ["bevy_asset", "bevy_sprite", "bevy/bevy_winit"]
+required-features = ["bevy_asset", "bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "sprite_color"
-required-features = ["bevy_sprite", "bevy/bevy_winit"]
+required-features = ["bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "transform_translation"
-required-features = ["bevy_sprite", "bevy/bevy_winit"]
+required-features = ["bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "transform_rotation"
-required-features = ["bevy_sprite", "bevy/bevy_winit"]
+required-features = ["bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "ui_position"
-required-features = ["bevy_sprite", "bevy_ui", "bevy/bevy_winit"]
+required-features = ["bevy_sprite", "bevy_ui", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "text_color"
-required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit"]
+required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "sequence"
-required-features = ["bevy_sprite", "bevy_text", "bevy/bevy_winit"]
+required-features = ["bevy_sprite", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [workspace]
 resolver = "2"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 bevy_tweening = { path = "../" }
 
 [dependencies.bevy]
-version = "0.15"
+version = "0.16.0-rc"
 default-features = false
 features = ["bevy_render", "bevy_sprite", "bevy_text", "bevy_ui"]
 

--- a/benchmarks/benches/lens.rs
+++ b/benchmarks/benches/lens.rs
@@ -3,7 +3,7 @@ extern crate criterion;
 
 use bevy::{
     color::palettes::css::{BLUE, RED},
-    ecs::component::Tick,
+    ecs::{change_detection::MaybeLocation, component::Tick},
     prelude::*,
 };
 use bevy_tweening::{lens::*, ComponentTarget};
@@ -17,12 +17,14 @@ fn text_color_lens(c: &mut Criterion) {
     let mut text_color = TextColor::default();
     let mut added = Tick::new(0);
     let mut last_changed = Tick::new(0);
+    let mut caller = MaybeLocation::caller();
     let mut target = ComponentTarget::new(Mut::new(
         &mut text_color,
         &mut added,
         &mut last_changed,
         Tick::new(0),
         Tick::new(0),
+        caller.as_mut(),
     ));
     c.bench_function("TextColorLens", |b| {
         b.iter(|| lens.lerp(&mut target, black_box(0.3)))
@@ -37,12 +39,14 @@ fn transform_position_lens(c: &mut Criterion) {
     let mut transform = Transform::IDENTITY;
     let mut added = Tick::new(0);
     let mut last_changed = Tick::new(0);
+    let mut caller = MaybeLocation::caller();
     let mut target = ComponentTarget::new(Mut::new(
         &mut transform,
         &mut added,
         &mut last_changed,
         Tick::new(0),
         Tick::new(0),
+        caller.as_mut(),
     ));
     c.bench_function("TransformPositionLens", |b| {
         b.iter(|| lens.lerp(&mut target, black_box(0.3)))
@@ -57,12 +61,14 @@ fn transform_rotation_lens(c: &mut Criterion) {
     let mut transform = Transform::IDENTITY;
     let mut added = Tick::new(0);
     let mut last_changed = Tick::new(0);
+    let mut caller = MaybeLocation::caller();
     let mut target = ComponentTarget::new(Mut::new(
         &mut transform,
         &mut added,
         &mut last_changed,
         Tick::new(0),
         Tick::new(0),
+        caller.as_mut(),
     ));
     c.bench_function("TransformRotationLens", |b| {
         b.iter(|| lens.lerp(&mut target, black_box(0.3)))
@@ -77,12 +83,14 @@ fn transform_scale_lens(c: &mut Criterion) {
     let mut transform = Transform::IDENTITY;
     let mut added = Tick::new(0);
     let mut last_changed = Tick::new(0);
+    let mut caller = MaybeLocation::caller();
     let mut target = ComponentTarget::new(Mut::new(
         &mut transform,
         &mut added,
         &mut last_changed,
         Tick::new(0),
         Tick::new(0),
+        caller.as_mut(),
     ));
     c.bench_function("TransformScaleLens", |b| {
         b.iter(|| lens.lerp(&mut target, black_box(0.3)))

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -1,5 +1,5 @@
 use bevy::{color::palettes::css::*, prelude::*};
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, quick::WorldInspectorPlugin};
 use bevy_tweening::{lens::*, *};
 use std::time::Duration;
 
@@ -24,20 +24,25 @@ const INIT_TRANSITION_DONE: u64 = 1;
 /// marker.
 fn main() {
     App::default()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Menu".to_string(),
-                resolution: (800., 400.).into(),
-                present_mode: bevy::window::PresentMode::Fifo, // vsync
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "Menu".to_string(),
+                    resolution: (800., 400.).into(),
+                    present_mode: bevy::window::PresentMode::Fifo, // vsync
+                    ..default()
+                }),
                 ..default()
             }),
-            ..default()
-        }))
+            EguiPlugin {
+                enable_multipass_for_primary_context: true,
+            },
+            WorldInspectorPlugin::new(),
+            TweeningPlugin,
+        ))
         .add_systems(Update, utils::close_on_esc)
         .add_systems(Update, interaction)
         .add_systems(Update, enable_interaction_after_initial_animation)
-        .add_plugins(TweeningPlugin)
-        .add_plugins(WorldInspectorPlugin::new())
         .add_systems(Startup, setup)
         .run();
 }

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -194,24 +194,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 fn update_text(
-    query_text_red: Query<&Children, With<RedProgress>>,
-    query_text_blue: Query<&Children, With<BlueProgress>>,
+    red_text_children: Single<&Children, With<RedProgress>>,
+    blue_text_children: Single<&Children, With<BlueProgress>>,
     mut text_spans: Query<&mut TextSpan, With<ProgressValue>>,
-    query_anim_red: Query<&Animator<Transform>, With<RedSprite>>,
-    query_anim_blue: Query<&Animator<Transform>, With<BlueSprite>>,
+    anim_red: Single<&Animator<Transform>, With<RedSprite>>,
+    anim_blue: Single<&Animator<Transform>, With<BlueSprite>>,
     mut query_event: EventReader<TweenCompleted>,
 ) {
-    let anim_red = query_anim_red.single();
     let progress_red = anim_red.tweenable().progress();
 
-    let anim_blue = query_anim_blue.single();
     let progress_blue = anim_blue.tweenable().progress();
 
-    let red_text_children = query_text_red.single();
     let mut red_text = text_spans.get_mut(red_text_children[1]).unwrap();
     red_text.0 = format!("{:5.1}%", progress_red * 100.);
 
-    let blue_text_children = query_text_blue.single();
     let mut blue_text = text_spans.get_mut(blue_text_children[1]).unwrap();
     blue_text.0 = format!("{:5.1}%", progress_blue * 100.);
 

--- a/examples/transform_rotation.rs
+++ b/examples/transform_rotation.rs
@@ -1,5 +1,5 @@
 use bevy::{color::palettes::css::*, prelude::*};
-use bevy_inspector_egui::{prelude::*, quick::ResourceInspectorPlugin};
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, prelude::*, quick::ResourceInspectorPlugin};
 
 use bevy_tweening::{lens::*, *};
 
@@ -7,25 +7,32 @@ mod utils;
 
 fn main() {
     App::default()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "TransformRotationLens".to_string(),
-                resolution: (1400., 600.).into(),
-                present_mode: bevy::window::PresentMode::Fifo, // vsync
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "TransformRotationLens".to_string(),
+                    resolution: (1400., 600.).into(),
+                    present_mode: bevy::window::PresentMode::Fifo, // vsync
+                    ..default()
+                }),
                 ..default()
             }),
-            ..default()
-        }))
+            EguiPlugin {
+                enable_multipass_for_primary_context: true,
+            },
+            ResourceInspectorPlugin::<Options>::new(),
+            TweeningPlugin,
+        ))
         .init_resource::<Options>()
+        .register_type::<Options>()
         .add_systems(Update, utils::close_on_esc)
-        .add_plugins(TweeningPlugin)
-        .add_plugins(ResourceInspectorPlugin::<Options>::new())
         .add_systems(Startup, setup)
         .add_systems(Update, update_animation_speed)
         .run();
 }
 
-#[derive(Copy, Clone, PartialEq, Resource, Reflect, InspectorOptions)]
+#[derive(Resource, Reflect, InspectorOptions)]
+#[reflect(InspectorOptions)]
 struct Options {
     #[inspector(min = 0.01, max = 100.)]
     speed: f32,

--- a/examples/transform_translation.rs
+++ b/examples/transform_translation.rs
@@ -1,5 +1,5 @@
 use bevy::{color::palettes::css::*, prelude::*};
-use bevy_inspector_egui::{prelude::*, quick::ResourceInspectorPlugin};
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, prelude::*, quick::ResourceInspectorPlugin};
 
 use bevy_tweening::{lens::*, *};
 
@@ -7,7 +7,7 @@ mod utils;
 
 fn main() {
     App::default()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugins((DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "TransformPositionLens".to_string(),
                 resolution: (1400., 600.).into(),
@@ -15,17 +15,24 @@ fn main() {
                 ..default()
             }),
             ..default()
-        }))
+        }),
+            EguiPlugin {
+                enable_multipass_for_primary_context: true,
+            },
+            //DefaultInspectorConfigPlugin,
+            ResourceInspectorPlugin::<Options>::new(),
+            TweeningPlugin,
+        ))
         .init_resource::<Options>()
-        .add_systems(Update, utils::close_on_esc)
-        .add_plugins(TweeningPlugin)
-        .add_plugins(ResourceInspectorPlugin::<Options>::default())
+        .register_type::<Options>()
+        .add_systems(Update, utils::close_on_esc)        
         .add_systems(Startup, setup)
         .add_systems(Update, update_animation_speed)
         .run();
 }
 
-#[derive(Copy, Clone, PartialEq, Resource, Reflect, InspectorOptions)]
+#[derive(Resource, Reflect, InspectorOptions)]
+#[reflect(InspectorOptions)]
 struct Options {
     #[inspector(min = 0.01, max = 100.)]
     speed: f32,

--- a/examples/ui_position.rs
+++ b/examples/ui_position.rs
@@ -1,5 +1,5 @@
 use bevy::{color::palettes::css::*, prelude::*};
-use bevy_inspector_egui::{prelude::*, quick::ResourceInspectorPlugin};
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, prelude::*, quick::ResourceInspectorPlugin};
 
 use bevy_tweening::{lens::*, *};
 
@@ -7,7 +7,8 @@ mod utils;
 
 fn main() {
     App::default()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "UiPositionLens".to_string(),
                 resolution: (1400., 600.).into(),
@@ -15,17 +16,23 @@ fn main() {
                 ..default()
             }),
             ..default()
-        }))
+        }),
+            EguiPlugin {
+                enable_multipass_for_primary_context: true,
+            },
+            ResourceInspectorPlugin::<Options>::new(),
+            TweeningPlugin,
+        ))
         .init_resource::<Options>()
+        .register_type::<Options>()
         .add_systems(Update, utils::close_on_esc)
-        .add_plugins(TweeningPlugin)
-        .add_plugins(ResourceInspectorPlugin::<Options>::new())
         .add_systems(Startup, setup)
         .add_systems(Update, update_animation_speed)
         .run();
 }
 
-#[derive(Copy, Clone, PartialEq, Resource, Reflect, InspectorOptions)]
+#[derive(Resource, Reflect, InspectorOptions)]
+#[reflect(InspectorOptions)]
 struct Options {
     #[inspector(min = 0.01, max = 100.)]
     speed: f32,

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -4,6 +4,6 @@ use bevy::prelude::*;
 
 pub fn close_on_esc(mut ev_app_exit: EventWriter<AppExit>, input: Res<ButtonInput<KeyCode>>) {
     if input.just_pressed(KeyCode::Escape) {
-        ev_app_exit.send(AppExit::Success);
+        ev_app_exit.write(AppExit::Success);
     }
 }

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -31,9 +31,9 @@
 //! - [`TransformRotateZLens`]
 //! - [`TransformRotateAxisLens`]
 //!
-//! [`rotation`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html#structfield.rotation
-//! [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
-//! [`Quat::slerp()`]: https://docs.rs/bevy/0.15.0/bevy/math/struct.Quat.html#method.slerp
+//! [`rotation`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html#structfield.rotation
+//! [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
+//! [`Quat::slerp()`]: https://docs.rs/bevy/0.16.0/bevy/math/struct.Quat.html#method.slerp
 
 use bevy::prelude::*;
 
@@ -79,7 +79,7 @@ pub trait Lens<T> {
 /// A lens to manipulate the [`color`] field of a section of a [`Text`]
 /// component.
 ///
-/// [`color`]: https://docs.rs/bevy/0.15.0/bevy/text/struct.TextColor.html
+/// [`color`]: https://docs.rs/bevy/0.16.0/bevy/text/struct.TextColor.html
 #[cfg(feature = "bevy_text")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TextColorLens {
@@ -98,8 +98,8 @@ impl Lens<TextColor> for TextColorLens {
 
 /// A lens to manipulate the [`translation`] field of a [`Transform`] component.
 ///
-/// [`translation`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html#structfield.translation
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
+/// [`translation`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html#structfield.translation
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformPositionLens {
     /// Start value of the translation.
@@ -128,9 +128,9 @@ impl Lens<Transform> for TransformPositionLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`rotation`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html#structfield.rotation
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
-/// [`Quat::slerp()`]: https://docs.rs/bevy/0.15.0/bevy/math/struct.Quat.html#method.slerp
+/// [`rotation`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html#structfield.rotation
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
+/// [`Quat::slerp()`]: https://docs.rs/bevy/0.16.0/bevy/math/struct.Quat.html#method.slerp
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotationLens {
@@ -156,7 +156,7 @@ impl Lens<Transform> for TransformRotationLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateXLens {
@@ -183,7 +183,7 @@ impl Lens<Transform> for TransformRotateXLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateYLens {
@@ -210,7 +210,7 @@ impl Lens<Transform> for TransformRotateYLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateZLens {
@@ -241,7 +241,7 @@ impl Lens<Transform> for TransformRotateZLens {
 ///
 /// This method panics if the `axis` vector is not normalized.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateAxisLens {
@@ -262,8 +262,8 @@ impl Lens<Transform> for TransformRotateAxisLens {
 
 /// A lens to manipulate the [`scale`] field of a [`Transform`] component.
 ///
-/// [`scale`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html#structfield.scale
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
+/// [`scale`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html#structfield.scale
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformScaleLens {
     /// Start value of the scale.
@@ -280,8 +280,8 @@ impl Lens<Transform> for TransformScaleLens {
 
 /// A lens to manipulate the [`position`] field of a UI [`Node`] component.
 ///
-/// [`position`]: https://docs.rs/bevy/0.15.0/bevy/ui/struct.Node.html
-/// [`Node`]: https://docs.rs/bevy/0.15.0/bevy/ui/struct.Node.html
+/// [`position`]: https://docs.rs/bevy/0.16.0/bevy/ui/struct.Node.html
+/// [`Node`]: https://docs.rs/bevy/0.16.0/bevy/ui/struct.Node.html
 #[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiPositionLens {
@@ -335,8 +335,8 @@ impl Lens<BackgroundColor> for UiBackgroundColorLens {
 
 /// A lens to manipulate the [`color`] field of a [`ColorMaterial`] asset.
 ///
-/// [`color`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.ColorMaterial.html#structfield.color
-/// [`ColorMaterial`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.ColorMaterial.html
+/// [`color`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.ColorMaterial.html#structfield.color
+/// [`ColorMaterial`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.ColorMaterial.html
 #[cfg(all(feature = "bevy_sprite", feature = "bevy_asset"))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ColorMaterialColorLens {
@@ -355,8 +355,8 @@ impl Lens<ColorMaterial> for ColorMaterialColorLens {
 
 /// A lens to manipulate the [`color`] field of a [`Sprite`] asset.
 ///
-/// [`color`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.Sprite.html#structfield.color
-/// [`Sprite`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.Sprite.html
+/// [`color`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.Sprite.html#structfield.color
+/// [`Sprite`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.Sprite.html
 #[cfg(feature = "bevy_sprite")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct SpriteColorLens {

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -376,7 +376,7 @@ impl Lens<Sprite> for SpriteColorLens {
 
 #[cfg(test)]
 mod tests {
-    use bevy::ecs::component::Tick;
+    use bevy::ecs::{change_detection::MaybeLocation, component::Tick};
     use std::f32::consts::TAU;
 
     #[cfg(any(feature = "bevy_sprite", feature = "bevy_text"))]
@@ -402,12 +402,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut text_color,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.);
@@ -417,12 +419,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut text_color,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 1.);
@@ -432,12 +436,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut text_color,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.3);
@@ -456,12 +462,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.);
@@ -473,12 +481,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 1.);
@@ -492,12 +502,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.3);
@@ -520,12 +532,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.);
@@ -537,12 +551,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 1.);
@@ -556,12 +572,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.3);
@@ -585,12 +603,14 @@ mod tests {
             {
                 let mut added = Tick::new(0);
                 let mut last_changed = Tick::new(0);
+                let mut caller = MaybeLocation::caller();
                 let mut target = ComponentTarget::new(Mut::new(
                     &mut transform,
                     &mut added,
                     &mut last_changed,
                     Tick::new(0),
                     Tick::new(0),
+                    caller.as_mut(),
                 ));
 
                 lens.lerp(&mut target, *ratio);
@@ -612,12 +632,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.1);
@@ -641,12 +663,14 @@ mod tests {
             {
                 let mut added = Tick::new(0);
                 let mut last_changed = Tick::new(0);
+                let mut caller = MaybeLocation::caller();
                 let mut target = ComponentTarget::new(Mut::new(
                     &mut transform,
                     &mut added,
                     &mut last_changed,
                     Tick::new(0),
                     Tick::new(0),
+                    caller.as_mut(),
                 ));
 
                 lens.lerp(&mut target, *ratio);
@@ -668,12 +692,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.1);
@@ -697,12 +723,14 @@ mod tests {
             {
                 let mut added = Tick::new(0);
                 let mut last_changed = Tick::new(0);
+                let mut caller = MaybeLocation::caller();
                 let mut target = ComponentTarget::new(Mut::new(
                     &mut transform,
                     &mut added,
                     &mut last_changed,
                     Tick::new(0),
                     Tick::new(0),
+                    caller.as_mut(),
                 ));
 
                 lens.lerp(&mut target, *ratio);
@@ -724,12 +752,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.1);
@@ -755,12 +785,14 @@ mod tests {
             {
                 let mut added = Tick::new(0);
                 let mut last_changed = Tick::new(0);
+                let mut caller = MaybeLocation::caller();
                 let mut target = ComponentTarget::new(Mut::new(
                     &mut transform,
                     &mut added,
                     &mut last_changed,
                     Tick::new(0),
                     Tick::new(0),
+                    caller.as_mut(),
                 ));
 
                 lens.lerp(&mut target, *ratio);
@@ -782,12 +814,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.1);
@@ -810,12 +844,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.);
@@ -827,12 +863,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 1.);
@@ -844,12 +882,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut transform,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.3);
@@ -881,12 +921,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut node,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.);
@@ -899,12 +941,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut node,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 1.);
@@ -917,12 +961,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut node,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.3);
@@ -950,12 +996,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = AssetTarget::new(Mut::new(
                 &mut assets,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
             target.handle = handle.clone();
 
@@ -966,12 +1014,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = AssetTarget::new(Mut::new(
                 &mut assets,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
             target.handle = handle.clone();
 
@@ -982,12 +1032,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = AssetTarget::new(Mut::new(
                 &mut assets,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
             target.handle = handle.clone();
 
@@ -1014,12 +1066,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut sprite,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.);
@@ -1029,12 +1083,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut sprite,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 1.);
@@ -1044,12 +1100,14 @@ mod tests {
         {
             let mut added = Tick::new(0);
             let mut last_changed = Tick::new(0);
+            let mut caller = MaybeLocation::caller();
             let mut target = ComponentTarget::new(Mut::new(
                 &mut sprite,
                 &mut added,
                 &mut last_changed,
                 Tick::new(0),
                 Tick::new(0),
+                caller.as_mut(),
             ));
 
             lens.lerp(&mut target, 0.3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,14 +195,14 @@
 //! lens can also be created by implementing the trait, allowing to animate
 //! virtually any field of any Bevy component or asset.
 //!
-//! [`Transform::translation`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html#structfield.translation
-//! [`Entity`]: https://docs.rs/bevy/0.15.0/bevy/ecs/entity/struct.Entity.html
-//! [`Query`]: https://docs.rs/bevy/0.15.0/bevy/ecs/system/struct.Query.html
-//! [`ColorMaterial`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.ColorMaterial.html
-//! [`Sprite`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.Sprite.html
-//! [`Node`]: https://docs.rs/bevy/0.15.0/bevy/ui/struct.Node.html#structfield.position
-//! [`TextColor`]: https://docs.rs/bevy/0.15.0/bevy/text/struct.TextColor.html
-//! [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
+//! [`Transform::translation`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html#structfield.translation
+//! [`Entity`]: https://docs.rs/bevy/0.16.0/bevy/ecs/entity/struct.Entity.html
+//! [`Query`]: https://docs.rs/bevy/0.16.0/bevy/ecs/system/struct.Query.html
+//! [`ColorMaterial`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.ColorMaterial.html
+//! [`Sprite`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.Sprite.html
+//! [`Node`]: https://docs.rs/bevy/0.16.0/bevy/ui/struct.Node.html#structfield.position
+//! [`TextColor`]: https://docs.rs/bevy/0.16.0/bevy/text/struct.TextColor.html
+//! [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
 
 use std::time::Duration;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //!
 //! commands.spawn((
 //!     // Spawn an entity to animate the position of.
-//!     TransformBundle::default(),
+//!     Transform::default(),
 //!     // Add an Animator component to control and execute the animation.
 //!     Animator::new(tween),
 //! ));
@@ -580,7 +580,7 @@ impl<T: Asset> AssetAnimator<T> {
 
 #[cfg(test)]
 mod tests {
-    use bevy::ecs::component::Tick;
+    use bevy::ecs::{change_detection::MaybeLocation, component::Tick};
 
     use self::tweenable::ComponentTarget;
 
@@ -617,12 +617,14 @@ mod tests {
             {
                 let mut added = Tick::new(0);
                 let mut last_changed = Tick::new(0);
+                let mut caller = MaybeLocation::caller();
                 let mut target = ComponentTarget::new(Mut::new(
                     &mut c,
                     &mut added,
                     &mut last_changed,
                     Tick::new(0),
                     Tick::new(1),
+                    caller.as_mut(),
                 ));
 
                 l.lerp(&mut target, r);
@@ -654,12 +656,14 @@ mod tests {
             {
                 let mut added = Tick::new(0);
                 let mut last_changed = Tick::new(0);
+                let mut caller = MaybeLocation::caller();
                 let mut target = AssetTarget::new(Mut::new(
                     &mut assets,
                     &mut added,
                     &mut last_changed,
                     Tick::new(0),
                     Tick::new(0),
+                    caller.as_mut(),
                 ));
                 target.handle = handle.clone();
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{ecs::component::Mutable, prelude::*};
 
 #[cfg(feature = "bevy_asset")]
 use crate::{tweenable::AssetTarget, AssetAnimator};
@@ -85,7 +85,7 @@ pub enum AnimationSystem {
 ///
 /// This system extracts all components of type `T` with an [`Animator<T>`]
 /// attached to the same entity, and tick the animator to animate the component.
-pub fn component_animator_system<T: Component>(
+pub fn component_animator_system<T: Component<Mutability = Mutable>>(
     time: Res<Time>,
     mut animator_query: Query<(Entity, &mut Animator<T>)>,
     mut target_query: Query<&mut T>,
@@ -163,6 +163,8 @@ mod tests {
         },
     };
 
+    use bevy::ecs::component::Mutable;
+
     use crate::{lens::TransformPositionLens, *};
 
     /// A simple isolated test environment with a [`World`] and a single
@@ -210,7 +212,7 @@ mod tests {
         }
     }
 
-    impl<T: Component> TestEnv<T> {
+    impl<T: Component<Mutability = Mutable>> TestEnv<T> {
         /// Get the test world.
         pub fn world_mut(&mut self) -> &mut World {
             &mut self.world
@@ -262,7 +264,7 @@ mod tests {
     #[test]
     fn custom_target_entity() {
         let tween = Tween::new(
-            EaseMethod::Linear,
+            EaseMethod::EaseFunction(EaseFunction::Linear),
             Duration::from_secs(1),
             TransformPositionLens {
                 start: Vec3::ZERO,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -27,11 +27,11 @@ use crate::{tweenable::ComponentTarget, Animator, AnimatorState, TweenCompleted}
 /// add manually the relevant systems for the exact set of components and assets
 /// actually animated.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.15.0/bevy/transform/components/struct.Transform.html
-/// [`TextColor`]: https://docs.rs/bevy/0.15.0/bevy/text/struct.TextColor.html
-/// [`Node`]: https://docs.rs/bevy/0.15.0/bevy/ui/struct.Node.html
-/// [`Sprite`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.Sprite.html
-/// [`ColorMaterial`]: https://docs.rs/bevy/0.15.0/bevy/sprite/struct.ColorMaterial.html
+/// [`Transform`]: https://docs.rs/bevy/0.16.0/bevy/transform/components/struct.Transform.html
+/// [`TextColor`]: https://docs.rs/bevy/0.16.0/bevy/text/struct.TextColor.html
+/// [`Node`]: https://docs.rs/bevy/0.16.0/bevy/ui/struct.Node.html
+/// [`Sprite`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.Sprite.html
+/// [`ColorMaterial`]: https://docs.rs/bevy/0.16.0/bevy/sprite/struct.ColorMaterial.html
 #[derive(Debug, Clone, Copy)]
 pub struct TweeningPlugin;
 

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1358,7 +1358,13 @@ impl<T> Tweenable<T> for Delay<T> {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use bevy::ecs::{component::Tick, event::Events, system::SystemState, world::CommandQueue};
+    use bevy::ecs::{
+        change_detection::MaybeLocation,
+        component::{Mutable, Tick},
+        event::Events,
+        system::SystemState,
+        world::CommandQueue,
+    };
 
     use super::*;
     use crate::{lens::*, test_utils::*};
@@ -1394,7 +1400,7 @@ mod tests {
     fn oneshot_test() {}
 
     /// Manually tick a test tweenable targeting a component.
-    fn manual_tick_component<T: Component>(
+    fn manual_tick_component<T: Component<Mutability = Mutable>>(
         duration: Duration,
         tween: &mut dyn Tweenable<T>,
         world: &mut World,
@@ -1428,12 +1434,14 @@ mod tests {
         let mut c = DummyComponent::default();
         let mut added = Tick::new(0);
         let mut last_changed = Tick::new(0);
+        let mut caller = MaybeLocation::caller();
         let mut target = ComponentTarget::new(Mut::new(
             &mut c,
             &mut added,
             &mut last_changed,
             Tick::new(0),
             Tick::new(1),
+            caller.as_mut(),
         ));
         let mut target = target.to_mut();
 


### PR DESCRIPTION
Easy upgrade, currently pointing at my branches for bevy_egui and bevy_inspector_egui.

Two Notes:

- Had to add bevy/bevy_picking to examples requirements, while bevy_egui doesn't use picking directly, get a runtime error without it
```Encountered an error in system `bevy_egui::capture_pointer_input_system`: SystemParamValidationError { skipped: false }```

- 0.16 added "std" and "libm" that switches out the math lib and transforms, we need those, should all bevy addons add features to reflect this?

