### PR TITLE
Fix panic when constructing empty tracks

### DIFF
--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1003,7 +1003,7 @@ impl<T> Tracks<T> {
             .map(AsRef::as_ref)
             .map(Tweenable::duration)
             .max()
-            .unwrap();
+            .unwrap_or(Duration::ZERO);
         Self {
             tracks,
             duration,


### PR DESCRIPTION
Fall back to a duration of zero if no tweenables are given to the tracks constructor.