### PR TITLE
Add a param generic to Animator to allow multiple tweens over the same component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "bevy_tweening"
 version = "0.13.0"
 authors = [
-    "François Mockers <mockersf@gmail.com>",
-    "Jerome Humbert <djeedai@gmail.com>",
+  "François Mockers <mockersf@gmail.com>",
+  "Jerome Humbert <djeedai@gmail.com>",
 ]
 edition = "2021"
 description = "Tweening animation plugin for the Bevy game engine"
@@ -28,18 +28,28 @@ bevy_text = ["bevy/bevy_text", "bevy/bevy_render", "bevy/bevy_sprite"]
 
 [dependencies]
 # Note: abuse 'bevy_color' to force 'bevy_math/curve' feature, which defines EaseFunction
-bevy = { version = "0.16", default-features = false, features = [ "bevy_color" ]}
+bevy = { version = "0.16", default-features = false, features = ["bevy_color"] }
 
 [dev-dependencies]
 bevy-inspector-egui = { version = "0.31" }
 
 [[example]]
 name = "menu"
-required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
+required-features = [
+  "bevy_ui",
+  "bevy_text",
+  "bevy/bevy_winit",
+  "bevy/bevy_picking",
+]
 
 [[example]]
 name = "colormaterial_color"
-required-features = ["bevy_asset", "bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
+required-features = [
+  "bevy_asset",
+  "bevy_sprite",
+  "bevy/bevy_winit",
+  "bevy/bevy_picking",
+]
 
 [[example]]
 name = "sprite_color"
@@ -55,15 +65,38 @@ required-features = ["bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "ui_position"
-required-features = ["bevy_sprite", "bevy_ui", "bevy/bevy_winit", "bevy/bevy_picking"]
+required-features = [
+  "bevy_sprite",
+  "bevy_ui",
+  "bevy/bevy_winit",
+  "bevy/bevy_picking",
+]
 
 [[example]]
 name = "text_color"
-required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
+required-features = [
+  "bevy_ui",
+  "bevy_text",
+  "bevy/bevy_winit",
+  "bevy/bevy_picking",
+]
 
 [[example]]
 name = "sequence"
-required-features = ["bevy_sprite", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
+required-features = [
+  "bevy_sprite",
+  "bevy_text",
+  "bevy/bevy_winit",
+  "bevy/bevy_picking",
+]
+
+[[example]]
+name = "custom_relative_lens"
+required-features = ["bevy/bevy_winit"]
+
+[[example]]
+name = "transform_marker"
+required-features = ["bevy/bevy_winit"]
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "bevy_tweening"
 version = "0.13.0"
 authors = [
-  "François Mockers <mockersf@gmail.com>",
-  "Jerome Humbert <djeedai@gmail.com>",
+    "François Mockers <mockersf@gmail.com>",
+    "Jerome Humbert <djeedai@gmail.com>",
 ]
 edition = "2021"
 description = "Tweening animation plugin for the Bevy game engine"
@@ -28,28 +28,18 @@ bevy_text = ["bevy/bevy_text", "bevy/bevy_render", "bevy/bevy_sprite"]
 
 [dependencies]
 # Note: abuse 'bevy_color' to force 'bevy_math/curve' feature, which defines EaseFunction
-bevy = { version = "0.16", default-features = false, features = ["bevy_color"] }
+bevy = { version = "0.16", default-features = false, features = [ "bevy_color" ]}
 
 [dev-dependencies]
 bevy-inspector-egui = { version = "0.31" }
 
 [[example]]
 name = "menu"
-required-features = [
-  "bevy_ui",
-  "bevy_text",
-  "bevy/bevy_winit",
-  "bevy/bevy_picking",
-]
+required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "colormaterial_color"
-required-features = [
-  "bevy_asset",
-  "bevy_sprite",
-  "bevy/bevy_winit",
-  "bevy/bevy_picking",
-]
+required-features = ["bevy_asset", "bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "sprite_color"
@@ -65,34 +55,15 @@ required-features = ["bevy_sprite", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "ui_position"
-required-features = [
-  "bevy_sprite",
-  "bevy_ui",
-  "bevy/bevy_winit",
-  "bevy/bevy_picking",
-]
+required-features = ["bevy_sprite", "bevy_ui", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "text_color"
-required-features = [
-  "bevy_ui",
-  "bevy_text",
-  "bevy/bevy_winit",
-  "bevy/bevy_picking",
-]
+required-features = ["bevy_ui", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "sequence"
-required-features = [
-  "bevy_sprite",
-  "bevy_text",
-  "bevy/bevy_winit",
-  "bevy/bevy_picking",
-]
-
-[[example]]
-name = "custom_relative_lens"
-required-features = ["bevy/bevy_winit"]
+required-features = ["bevy_sprite", "bevy_text", "bevy/bevy_winit", "bevy/bevy_picking"]
 
 [[example]]
 name = "transform_marker"

--- a/examples/transform_marker.rs
+++ b/examples/transform_marker.rs
@@ -1,0 +1,117 @@
+use bevy::{color::palettes::css::*, prelude::*};
+use bevy_inspector_egui::{bevy_egui::EguiPlugin, prelude::*, quick::ResourceInspectorPlugin};
+
+use bevy_tweening::{lens::*, *};
+
+mod utils;
+
+fn main() {
+    App::default()
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "TransformPositionLens".to_string(),
+                    resolution: (1400., 600.).into(),
+                    present_mode: bevy::window::PresentMode::Fifo, // vsync
+                    ..default()
+                }),
+                ..default()
+            }),
+            EguiPlugin {
+                enable_multipass_for_primary_context: true,
+            },
+            //DefaultInspectorConfigPlugin,
+            ResourceInspectorPlugin::<Options>::new(),
+            TweeningPlugin,
+        ))
+        .init_resource::<Options>()
+        .register_type::<Options>()
+        .add_systems(Update, utils::close_on_esc)
+        .add_systems(Startup, setup)
+        .add_systems(Update, update_animation_speed)
+        .add_systems(
+            Update,
+            (
+                component_animator_system::<Transform, TransformTranslation>,
+                component_animator_system::<Transform, TransformScale>,
+                component_animator_system::<Transform, TransformRotation>,
+            ),
+        )
+        .run();
+}
+
+#[derive(Resource, Reflect, InspectorOptions)]
+#[reflect(InspectorOptions)]
+struct Options {
+    #[inspector(min = 0.01, max = 100.)]
+    speed: f32,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self { speed: 1. }
+    }
+}
+
+struct TransformTranslation;
+struct TransformScale;
+struct TransformRotation;
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d::default());
+
+    let size = 25.;
+    let screen_y = 150.;
+
+    let translation_tween = Tween::<_, TransformTranslation>::new_with_marker(
+        EaseFunction::QuadraticInOut,
+        std::time::Duration::from_secs(1),
+        TransformPositionLens {
+            start: Vec3::new(0., screen_y, 0.),
+            end: Vec3::new(0., -screen_y, 0.),
+        },
+    )
+    .with_repeat_count(RepeatCount::Infinite)
+    .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+    let scale_tween = Tween::<_, TransformScale>::new_with_marker(
+        EaseFunction::SineInOut,
+        std::time::Duration::from_secs_f32(0.5),
+        TransformScaleLens {
+            start: Vec3::ONE,
+            end: Vec2::splat(1.5).extend(1.),
+        },
+    )
+    .with_repeat_count(RepeatCount::Infinite)
+    .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+    let rotation_tween = Tween::new(
+        EaseFunction::QuarticInOut,
+        std::time::Duration::from_secs_f32(0.75),
+        TransformRotationLens {
+            start: Quat::IDENTITY,
+            end: Quat::from_axis_angle(Vec3::Z, std::f32::consts::PI / 2.),
+        },
+    )
+    .with_repeat_count(RepeatCount::Infinite)
+    .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
+
+    commands.spawn((
+        Sprite {
+            color: RED.into(),
+            custom_size: Some(Vec2::splat(size)),
+            ..default()
+        },
+        Animator::new(translation_tween),
+        Animator::new(scale_tween),
+        Animator::new(rotation_tween),
+    ));
+}
+
+fn update_animation_speed(options: Res<Options>, mut animators: Query<&mut Animator<Transform>>) {
+    if !options.is_changed() {
+        return;
+    }
+
+    for mut animator in animators.iter_mut() {
+        animator.set_speed(options.speed);
+    }
+}

--- a/examples/transform_marker.rs
+++ b/examples/transform_marker.rs
@@ -63,7 +63,7 @@ fn setup(mut commands: Commands) {
     let size = 25.;
     let screen_y = 150.;
 
-    let translation_tween = Tween::<_, TransformTranslation>::new_with_marker(
+    let translation_tween = Tween::new(
         EaseFunction::QuadraticInOut,
         std::time::Duration::from_secs(1),
         TransformPositionLens {
@@ -73,7 +73,7 @@ fn setup(mut commands: Commands) {
     )
     .with_repeat_count(RepeatCount::Infinite)
     .with_repeat_strategy(RepeatStrategy::MirroredRepeat);
-    let scale_tween = Tween::<_, TransformScale>::new_with_marker(
+    let scale_tween = Tween::new(
         EaseFunction::SineInOut,
         std::time::Duration::from_secs_f32(0.5),
         TransformScaleLens {
@@ -100,9 +100,9 @@ fn setup(mut commands: Commands) {
             custom_size: Some(Vec2::splat(size)),
             ..default()
         },
-        Animator::new(translation_tween),
-        Animator::new(scale_tween),
-        Animator::new(rotation_tween),
+        Animator::<_, TransformTranslation>::new_with_marker(translation_tween),
+        Animator::<_, TransformScale>::new_with_marker(scale_tween),
+        Animator::<_, TransformRotation>::new_with_marker(rotation_tween),
     ));
 }
 

--- a/examples/transform_marker.rs
+++ b/examples/transform_marker.rs
@@ -100,9 +100,9 @@ fn setup(mut commands: Commands) {
             custom_size: Some(Vec2::splat(size)),
             ..default()
         },
-        Animator::<_, TransformTranslation>::new_with_marker(translation_tween),
-        Animator::<_, TransformScale>::new_with_marker(scale_tween),
-        Animator::<_, TransformRotation>::new_with_marker(rotation_tween),
+        Animator::new(translation_tween).with_marker::<TransformTranslation>(),
+        Animator::new(scale_tween).with_marker::<TransformScale>(),
+        Animator::new(rotation_tween).with_marker::<TransformRotation>(),
     ));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,19 +470,19 @@ macro_rules! animator_impl {
         }
 
         /// Set the top-level tweenable item this animator controls.
-        pub fn set_tweenable(&mut self, tween: impl Tweenable<T> + 'static) {
+        pub fn set_tweenable(&mut self, tween: impl Tweenable<T, M> + 'static) {
             self.tweenable = Box::new(tween);
         }
 
         /// Get the top-level tweenable this animator is currently controlling.
         #[must_use]
-        pub fn tweenable(&self) -> &dyn Tweenable<T> {
+        pub fn tweenable(&self) -> &dyn Tweenable<T, M> {
             self.tweenable.as_ref()
         }
 
         /// Get the top-level mutable tweenable this animator is currently controlling.
         #[must_use]
-        pub fn tweenable_mut(&mut self) -> &mut dyn Tweenable<T> {
+        pub fn tweenable_mut(&mut self) -> &mut dyn Tweenable<T, M> {
             self.tweenable.as_mut()
         }
 
@@ -503,16 +503,16 @@ macro_rules! animator_impl {
 /// entity as the [`Animator<T>`] itself. But if [`Animator::target`] is set,
 /// that entity will be used instead.
 #[derive(Component)]
-pub struct Animator<T: Component> {
+pub struct Animator<T: Component, M = ()> {
     /// Control if this animation is played or not.
     pub state: AnimatorState,
     /// When set, the animated component will be the one located on this entity.
     pub target: Option<Entity>,
-    tweenable: BoxedTweenable<T>,
+    tweenable: BoxedTweenable<T, M>,
     speed: f32,
 }
 
-impl<T: Component + std::fmt::Debug> std::fmt::Debug for Animator<T> {
+impl<T: Component + std::fmt::Debug, M> std::fmt::Debug for Animator<T, M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Animator")
             .field("state", &self.state)
@@ -520,10 +520,10 @@ impl<T: Component + std::fmt::Debug> std::fmt::Debug for Animator<T> {
     }
 }
 
-impl<T: Component> Animator<T> {
+impl<T: Component, M> Animator<T, M> {
     /// Create a new animator component from a single tweenable.
     #[must_use]
-    pub fn new(tween: impl Tweenable<T> + 'static) -> Self {
+    pub fn new(tween: impl Tweenable<T, M> + 'static) -> Self {
         Self {
             state: default(),
             tweenable: Box::new(tween),
@@ -547,10 +547,10 @@ impl<T: Component> Animator<T> {
 /// located on the same entity as the [`AssetAnimator<T>`] itself.
 #[cfg(feature = "bevy_asset")]
 #[derive(Component)]
-pub struct AssetAnimator<T: Asset> {
+pub struct AssetAnimator<T: Asset, M = ()> {
     /// Control if this animation is played or not.
     pub state: AnimatorState,
-    tweenable: BoxedTweenable<T>,
+    tweenable: BoxedTweenable<T, M>,
     speed: f32,
 }
 
@@ -564,10 +564,10 @@ impl<T: Asset + std::fmt::Debug> std::fmt::Debug for AssetAnimator<T> {
 }
 
 #[cfg(feature = "bevy_asset")]
-impl<T: Asset> AssetAnimator<T> {
+impl<T: Asset, M> AssetAnimator<T, M> {
     /// Create a new asset animator component from a single tweenable.
     #[must_use]
-    pub fn new(tween: impl Tweenable<T> + 'static) -> Self {
+    pub fn new(tween: impl Tweenable<T, M> + 'static) -> Self {
         Self {
             state: default(),
             tweenable: Box::new(tween),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,21 +533,20 @@ impl<T: Component> Animator<T> {
             _marker: Default::default(),
         }
     }
-}
 
-impl<T: Component, M> Animator<T, M> {
-    /// Create a new animator component from a single tweenable.
-    #[must_use]
-    pub fn new_with_marker(tween: impl Tweenable<T> + 'static) -> Self {
-        Self {
-            state: default(),
-            tweenable: Box::new(tween),
-            target: None,
-            speed: 1.,
+    /// Create a new version of this animator component with a marker
+    pub fn with_marker<M>(self) -> Animator<T, M> {
+        Animator::<T, M> {
+            state: self.state,
+            tweenable: self.tweenable,
+            target: self.target,
+            speed: self.speed,
             _marker: Default::default(),
         }
     }
+}
 
+impl<T: Component, M> Animator<T, M> {
     /// Create a new version of this animator with the `target` set to the given entity.
     pub fn with_target(mut self, entity: Entity) -> Self {
         self.target = Some(entity);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -39,24 +39,25 @@ impl Plugin for TweeningPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<TweenCompleted>().add_systems(
             Update,
-            component_animator_system::<Transform>.in_set(AnimationSystem::AnimationUpdate),
+            component_animator_system::<Transform, ()>.in_set(AnimationSystem::AnimationUpdate),
         );
 
         #[cfg(feature = "bevy_ui")]
         app.add_systems(
             Update,
-            component_animator_system::<Node>.in_set(AnimationSystem::AnimationUpdate),
+            component_animator_system::<Node, ()>.in_set(AnimationSystem::AnimationUpdate),
         );
         #[cfg(feature = "bevy_ui")]
         app.add_systems(
             Update,
-            component_animator_system::<BackgroundColor>.in_set(AnimationSystem::AnimationUpdate),
+            component_animator_system::<BackgroundColor, ()>
+                .in_set(AnimationSystem::AnimationUpdate),
         );
 
         #[cfg(feature = "bevy_sprite")]
         app.add_systems(
             Update,
-            component_animator_system::<Sprite>.in_set(AnimationSystem::AnimationUpdate),
+            component_animator_system::<Sprite, ()>.in_set(AnimationSystem::AnimationUpdate),
         );
 
         #[cfg(all(feature = "bevy_sprite", feature = "bevy_asset"))]
@@ -69,7 +70,7 @@ impl Plugin for TweeningPlugin {
         #[cfg(feature = "bevy_text")]
         app.add_systems(
             Update,
-            component_animator_system::<TextColor>.in_set(AnimationSystem::AnimationUpdate),
+            component_animator_system::<TextColor, ()>.in_set(AnimationSystem::AnimationUpdate),
         );
     }
 }
@@ -85,9 +86,9 @@ pub enum AnimationSystem {
 ///
 /// This system extracts all components of type `T` with an [`Animator<T>`]
 /// attached to the same entity, and tick the animator to animate the component.
-pub fn component_animator_system<T: Component<Mutability = Mutable>>(
+pub fn component_animator_system<T: Component<Mutability = Mutable>, M: 'static>(
     time: Res<Time>,
-    mut animator_query: Query<(Entity, &mut Animator<T>)>,
+    mut animator_query: Query<(Entity, &mut Animator<T, M>)>,
     mut target_query: Query<&mut T>,
     events: ResMut<Events<TweenCompleted>>,
     mut commands: Commands,
@@ -273,7 +274,7 @@ mod tests {
         )
         .with_completed_event(0);
         let mut env = TestEnv::new_separated(Animator::new(tween));
-        let mut system = IntoSystem::into_system(component_animator_system::<Transform>);
+        let mut system = IntoSystem::into_system(component_animator_system::<Transform, ()>);
         system.initialize(env.world_mut());
 
         env.tick(Duration::ZERO, &mut system);
@@ -305,7 +306,7 @@ mod tests {
 
         // fn nit() {}
         // let mut system = IntoSystem::into_system(nit);
-        let mut system = IntoSystem::into_system(component_animator_system::<Transform>);
+        let mut system = IntoSystem::into_system(component_animator_system::<Transform, ()>);
         system.initialize(env.world_mut());
 
         env.tick(Duration::ZERO, &mut system);
@@ -385,7 +386,7 @@ mod tests {
         let component = env.component_mut();
         assert!(component.is_changed());
 
-        let mut system = IntoSystem::into_system(component_animator_system::<DummyComponent>);
+        let mut system = IntoSystem::into_system(component_animator_system::<DummyComponent, ()>);
         system.initialize(env.world_mut());
 
         assert!(!defer.load(Ordering::SeqCst));

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -86,7 +86,7 @@ pub enum AnimationSystem {
 ///
 /// This system extracts all components of type `T` with an [`Animator<T>`]
 /// attached to the same entity, and tick the animator to animate the component.
-pub fn component_animator_system<T: Component<Mutability = Mutable>, M: 'static>(
+pub fn component_animator_system<T: Component<Mutability = Mutable>, M: Send + Sync + 'static>(
     time: Res<Time>,
     mut animator_query: Query<(Entity, &mut Animator<T, M>)>,
     mut target_query: Query<&mut T>,

--- a/src/tweenable.rs
+++ b/src/tweenable.rs
@@ -1,4 +1,5 @@
 use std::{
+    marker::PhantomData,
     ops::{Deref, DerefMut},
     time::Duration,
 };
@@ -51,7 +52,7 @@ use crate::{EaseMethod, Lens, RepeatCount, RepeatStrategy, TweeningDirection};
 ///     }
 /// }
 /// ```
-pub type BoxedTweenable<T> = Box<dyn Tweenable<T> + 'static>;
+pub type BoxedTweenable<T, M = ()> = Box<dyn Tweenable<T, M> + 'static>;
 
 /// Playback state of a [`Tweenable`].
 ///
@@ -291,7 +292,7 @@ impl<T: Asset> Targetable<T> for AssetTarget<'_, T> {
 }
 
 /// An animatable entity, either a single [`Tween`] or a collection of them.
-pub trait Tweenable<T>: Send + Sync {
+pub trait Tweenable<T, M = ()>: Send + Sync {
     /// Get the duration of a single iteration of the animation.
     ///
     /// Note that for [`RepeatStrategy::MirroredRepeat`], this is the duration
@@ -410,7 +411,7 @@ pub trait Tweenable<T>: Send + Sync {
 
 macro_rules! impl_boxed {
     ($tweenable:ty) => {
-        impl<T: 'static> From<$tweenable> for BoxedTweenable<T> {
+        impl<T: 'static, M: Send + Sync + 'static> From<$tweenable> for BoxedTweenable<T, M> {
             fn from(t: $tweenable) -> Self {
                 Box::new(t)
             }
@@ -418,10 +419,10 @@ macro_rules! impl_boxed {
     };
 }
 
-impl_boxed!(Tween<T>);
-impl_boxed!(Sequence<T>);
-impl_boxed!(Tracks<T>);
-impl_boxed!(Delay<T>);
+impl_boxed!(Tween<T, M>);
+impl_boxed!(Sequence<T, M>);
+impl_boxed!(Tracks<T, M>);
+impl_boxed!(Delay<T, M>);
 
 /// Type of a callback invoked when a [`Tween`] or [`Delay`] has completed.
 ///
@@ -429,17 +430,18 @@ impl_boxed!(Delay<T>);
 pub type CompletedCallback<T> = dyn Fn(Entity, &T) + Send + Sync + 'static;
 
 /// Single tweening animation instance.
-pub struct Tween<T> {
+pub struct Tween<T, M = ()> {
     ease_function: EaseMethod,
     clock: AnimClock,
     direction: TweeningDirection,
     lens: Box<dyn Lens<T> + Send + Sync + 'static>,
-    on_completed: Option<Box<CompletedCallback<Tween<T>>>>,
+    on_completed: Option<Box<CompletedCallback<Tween<T, M>>>>,
     event_data: Option<u64>,
     system_id: Option<SystemId>,
+    _marker: PhantomData<M>,
 }
 
-impl<T: 'static> Tween<T> {
+impl<T: 'static, M: Send + Sync + 'static> Tween<T, M> {
     /// Chain another [`Tweenable`] after this tween, making a [`Sequence`] with
     /// the two.
     ///
@@ -467,7 +469,7 @@ impl<T: 'static> Tween<T> {
     /// let seq = tween1.then(tween2);
     /// ```
     #[must_use]
-    pub fn then(self, tween: impl Tweenable<T> + 'static) -> Sequence<T> {
+    pub fn then(self, tween: impl Tweenable<T, M> + 'static) -> Sequence<T, M> {
         Sequence::with_capacity(2).then(self).then(tween)
     }
 }
@@ -502,9 +504,54 @@ impl<T> Tween<T> {
             on_completed: None,
             event_data: None,
             system_id: None,
+            _marker: Default::default(),
         }
     }
+}
 
+impl<T, M> Tween<T, M> {
+    /// Create a new tween animation with a marker.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_tweening::{lens::*, *};
+    /// # use bevy::math::{Vec3, curve::EaseFunction};
+    /// # use std::time::Duration;
+    ///
+    /// struct MyMarker;
+    ///
+    /// let tween = Tween::<_, MyMarker>::new_with_marker(
+    ///     EaseFunction::QuadraticInOut,
+    ///     Duration::from_secs(1),
+    ///     TransformPositionLens {
+    ///         start: Vec3::ZERO,
+    ///         end: Vec3::new(3.5, 0., 0.),
+    ///     },
+    /// );
+    /// ```
+    #[must_use]
+    pub fn new_with_marker<L>(
+        ease_function: impl Into<EaseMethod>,
+        duration: Duration,
+        lens: L,
+    ) -> Self
+    where
+        L: Lens<T> + Send + Sync + 'static,
+    {
+        Self {
+            ease_function: ease_function.into(),
+            clock: AnimClock::new(duration),
+            direction: TweeningDirection::Forward,
+            lens: Box::new(lens),
+            on_completed: None,
+            event_data: None,
+            system_id: None,
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<T, M> Tween<T, M> {
     /// Enable raising a completed event.
     ///
     /// If enabled, the tween will raise a [`TweenCompleted`] event when the
@@ -738,7 +785,7 @@ impl<T> Tween<T> {
     }
 }
 
-impl<T> Tweenable<T> for Tween<T> {
+impl<T, M: Send + Sync> Tweenable<T, M> for Tween<T, M> {
     fn duration(&self) -> Duration {
         self.clock.duration
     }
@@ -833,19 +880,20 @@ impl<T> Tweenable<T> for Tween<T> {
 }
 
 /// A sequence of tweens played back in order one after the other.
-pub struct Sequence<T> {
-    tweens: Vec<BoxedTweenable<T>>,
+pub struct Sequence<T, M = ()> {
+    tweens: Vec<BoxedTweenable<T, M>>,
     index: usize,
     duration: Duration,
     elapsed: Duration,
+    _marker: PhantomData<M>,
 }
 
-impl<T> Sequence<T> {
+impl<T, M> Sequence<T, M> {
     /// Create a new sequence of tweens.
     ///
     /// This method panics if the input collection is empty.
     #[must_use]
-    pub fn new(items: impl IntoIterator<Item = impl Into<BoxedTweenable<T>>>) -> Self {
+    pub fn new(items: impl IntoIterator<Item = impl Into<BoxedTweenable<T, M>>>) -> Self {
         let tweens: Vec<_> = items.into_iter().map(Into::into).collect();
         assert!(!tweens.is_empty());
 
@@ -864,19 +912,21 @@ impl<T> Sequence<T> {
             index: 0,
             duration,
             elapsed: Duration::ZERO,
+            _marker: Default::default(),
         }
     }
 
     /// Create a new sequence containing a single tween.
     #[must_use]
-    pub fn from_single(tween: impl Tweenable<T> + 'static) -> Self {
+    pub fn from_single(tween: impl Tweenable<T, M> + 'static) -> Self {
         let duration = tween.duration();
-        let boxed: BoxedTweenable<T> = Box::new(tween);
+        let boxed: BoxedTweenable<T, M> = Box::new(tween);
         Self {
             tweens: vec![boxed],
             index: 0,
             duration,
             elapsed: Duration::ZERO,
+            _marker: Default::default(),
         }
     }
 
@@ -888,12 +938,13 @@ impl<T> Sequence<T> {
             index: 0,
             duration: Duration::ZERO,
             elapsed: Duration::ZERO,
+            _marker: Default::default(),
         }
     }
 
     /// Append a [`Tweenable`] to this sequence.
     #[must_use]
-    pub fn then(mut self, tween: impl Tweenable<T> + 'static) -> Self {
+    pub fn then(mut self, tween: impl Tweenable<T, M> + 'static) -> Self {
         self.duration += tween.duration();
         self.tweens.push(Box::new(tween));
         self
@@ -907,12 +958,12 @@ impl<T> Sequence<T> {
 
     /// Get the current active tween in the sequence.
     #[must_use]
-    pub fn current(&self) -> &dyn Tweenable<T> {
+    pub fn current(&self) -> &dyn Tweenable<T, M> {
         self.tweens[self.index()].as_ref()
     }
 }
 
-impl<T> Tweenable<T> for Sequence<T> {
+impl<T, M: Send + Sync> Tweenable<T, M> for Sequence<T, M> {
     fn duration(&self) -> Duration {
         self.duration
     }
@@ -986,17 +1037,17 @@ impl<T> Tweenable<T> for Sequence<T> {
 }
 
 /// A collection of [`Tweenable`] executing in parallel.
-pub struct Tracks<T> {
-    tracks: Vec<BoxedTweenable<T>>,
+pub struct Tracks<T, M = ()> {
+    tracks: Vec<BoxedTweenable<T, M>>,
     duration: Duration,
     elapsed: Duration,
 }
 
-impl<T> Tracks<T> {
+impl<T, M> Tracks<T, M> {
     /// Create a new [`Tracks`] from an iterator over a collection of
     /// [`Tweenable`].
     #[must_use]
-    pub fn new(items: impl IntoIterator<Item = impl Into<BoxedTweenable<T>>>) -> Self {
+    pub fn new(items: impl IntoIterator<Item = impl Into<BoxedTweenable<T, M>>>) -> Self {
         let tracks: Vec<_> = items.into_iter().map(Into::into).collect();
         let duration = tracks
             .iter()
@@ -1012,7 +1063,7 @@ impl<T> Tracks<T> {
     }
 }
 
-impl<T> Tweenable<T> for Tracks<T> {
+impl<T, M> Tweenable<T, M> for Tracks<T, M> {
     fn duration(&self) -> Duration {
         self.duration
     }
@@ -1068,23 +1119,24 @@ impl<T> Tweenable<T> for Tracks<T> {
 /// and tracks, for example to delay the start of a tween in a track relative to
 /// another track. The `menu` example (`examples/menu.rs`) uses this technique
 /// to delay the animation of its buttons.
-pub struct Delay<T> {
+pub struct Delay<T, M = ()> {
     timer: Timer,
-    on_completed: Option<Box<CompletedCallback<Delay<T>>>>,
+    on_completed: Option<Box<CompletedCallback<Delay<T, M>>>>,
     event_data: Option<u64>,
     system_id: Option<SystemId>,
+    _marker: PhantomData<M>,
 }
 
-impl<T: 'static> Delay<T> {
+impl<T: 'static, M: Send + Sync + 'static> Delay<T, M> {
     /// Chain another [`Tweenable`] after this tween, making a [`Sequence`] with
     /// the two.
     #[must_use]
-    pub fn then(self, tween: impl Tweenable<T> + 'static) -> Sequence<T> {
+    pub fn then(self, tween: impl Tweenable<T, M> + 'static) -> Sequence<T, M> {
         Sequence::with_capacity(2).then(self).then(tween)
     }
 }
 
-impl<T> Delay<T> {
+impl<T, M> Delay<T, M> {
     /// Create a new [`Delay`] with a given duration.
     ///
     /// # Panics
@@ -1098,6 +1150,7 @@ impl<T> Delay<T> {
             on_completed: None,
             event_data: None,
             system_id: None,
+            _marker: Default::default(),
         }
     }
 
@@ -1297,7 +1350,7 @@ impl<T> Delay<T> {
     }
 }
 
-impl<T> Tweenable<T> for Delay<T> {
+impl<T, M: Send + Sync> Tweenable<T, M> for Delay<T, M> {
     fn duration(&self) -> Duration {
         self.timer.duration()
     }


### PR DESCRIPTION
I love using this crate, but not being tween parts of the same component at different times (I guess it might be possible to recreate a `Tracks` tweenable?) can be quite cumbersome (I'm looking at you, `Transform`). Enter marker components to have different types of animators based on the marker.

```rs
    commands.spawn((
        Sprite {
            color: RED.into(),
            custom_size: Some(Vec2::splat(size)),
            ..default()
        },
        Animator::new(translation_tween).with_marker::<TransformTranslation>(),
        Animator::new(scale_tween).with_marker::<TransformScale>(),
        Animator::new(rotation_tween).with_marker::<TransformRotation>(),
    ));
```

There's a bunch of stuff missing, hence the draft state. Lemme know if you think it would be of value.

### Things to do to move this out of draft state
- [ ] go-ahead from @djeedai 
- [ ] AssetAnimator
- [ ] docs
- [ ] tests
- [ ] better example to show how this might be useful compared to a `Tracks` tweenable
- [ ] dupe the animator systems to avoid introducing breaking changes?