### PR TITLE
make `TweenAnim` removal in `step_impl` infallible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2371,7 +2371,12 @@ impl TweenAnim {
         });
 
         for entity in to_remove.drain(..) {
-            world.entity_mut(entity).remove::<TweenAnim>();
+            world
+                .get_entity_mut(entity)
+                .map(|mut e| {
+                    e.remove::<TweenAnim>();
+                })
+                .ok();
         }
 
         world.flush();


### PR DESCRIPTION
The motivation is that in our project we use this construct
```rust
.spawn(...)
.observe(|trigger: On<AnimCompletedEvent>, mut commands: Commands| {
    commands.entity(trigger.event().event_target()).try_despawn();
});
```
to despawn entities when animation completes, but current implementation in `bevy_tweening` expects that entity exists. I'm a little puzzled by the fact that our observer runs before your component cleanup, but this PR fixes it anyway.