### PR TITLE
Other Bevy 0.19 updates that were part of the #171 PR...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ required-features = [
     "bevy/hdr",
     "bevy/tonemapping_luts",
     "bevy/bevy_post_process",
-	"bevy/zstd_rust",
 ]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tweening"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "François Mockers <mockersf@gmail.com>",
     "Jerome Humbert <djeedai@gmail.com>",
@@ -54,6 +54,7 @@ required-features = [
     "bevy/hdr",
     "bevy/tonemapping_luts",
     "bevy/bevy_post_process",
+	"bevy/zstd_rust",
 ]
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Compatibility of `bevy_tweening` versions:
 
 | `bevy_tweening` | `bevy` |
 | :--             | :--    |
+| `0.16`          | `0.19` |
 | `0.15`          | `0.18` |
 | `0.14`          | `0.17` |
 | `0.13`          | `0.16` |

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -118,14 +118,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             Text::new(text.to_string()),
                             TextFont {
                                 font: font.clone().into(),
-                                font_size: 48.0.into(),
+                                font_size: FontSize::Px(48.0),
                                 ..default()
                             },
                             TextColor(TEXT_COLOR),
-                            TextLayout {
-                                justify: Justify::Center,
-                                ..default()
-                            },
+                            TextLayout::justify(Justify::Center),
                         )],
                     ))
                     .id();

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -44,7 +44,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) -> Result<()> {
     let font = asset_server.load("fonts/FiraMono-Regular.ttf");
     let text_font = TextFont {
         font: font.into(),
-        font_size: 50.0.into(),
+        font_size: FontSize::Px(50.0),
         ..default()
     };
 
@@ -57,10 +57,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) -> Result<()> {
     commands
         .spawn((
             Text2d::default(),
-            TextLayout {
-                justify,
-                ..default()
-            },
+            TextLayout::justify(justify),
             Transform::from_translation(Vec3::new(0., 40., 0.)),
             RedProgress,
         ))
@@ -82,10 +79,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) -> Result<()> {
     commands
         .spawn((
             Text2d::default(),
-            TextLayout {
-                justify,
-                ..default()
-            },
+            TextLayout::justify(justify),
             Transform::from_translation(Vec3::new(0., -40., 0.)),
             BlueProgress,
         ))

--- a/examples/text_color.rs
+++ b/examples/text_color.rs
@@ -85,7 +85,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             Text::new(*ease_name),
             TextFont {
                 font: font.clone().into(),
-                font_size: 24.0.into(),
+                font_size: FontSize::Px(24.0),
                 ..default()
             },
             TextColor(Color::WHITE),

--- a/src/lens.rs
+++ b/src/lens.rs
@@ -31,9 +31,9 @@
 //! - [`TransformRotateZLens`]
 //! - [`TransformRotateAxisLens`]
 //!
-//! [`rotation`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html#structfield.rotation
-//! [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
-//! [`Quat::slerp()`]: https://docs.rs/bevy/0.18/bevy/math/struct.Quat.html#method.slerp
+//! [`rotation`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html#structfield.rotation
+//! [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
+//! [`Quat::slerp()`]: https://docs.rs/bevy/0.19/bevy/math/struct.Quat.html#method.slerp
 
 use bevy::prelude::*;
 
@@ -77,7 +77,7 @@ pub trait Lens<T> {
 /// A lens to manipulate the [`color`] field of a section of a [`Text`]
 /// component.
 ///
-/// [`color`]: https://docs.rs/bevy/0.18/bevy/text/struct.TextColor.html
+/// [`color`]: https://docs.rs/bevy/0.19/bevy/text/struct.TextColor.html
 #[cfg(feature = "bevy_text")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TextColorLens {
@@ -96,8 +96,8 @@ impl Lens<TextColor> for TextColorLens {
 
 /// A lens to manipulate the [`translation`] field of a [`Transform`] component.
 ///
-/// [`translation`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html#structfield.translation
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`translation`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html#structfield.translation
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformPositionLens {
     /// Start value of the translation.
@@ -125,9 +125,9 @@ impl Lens<Transform> for TransformPositionLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`rotation`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html#structfield.rotation
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
-/// [`Quat::slerp()`]: https://docs.rs/bevy/0.18/bevy/math/struct.Quat.html#method.slerp
+/// [`rotation`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html#structfield.rotation
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
+/// [`Quat::slerp()`]: https://docs.rs/bevy/0.19/bevy/math/struct.Quat.html#method.slerp
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotationLens {
@@ -153,7 +153,7 @@ impl Lens<Transform> for TransformRotationLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateXLens {
@@ -180,7 +180,7 @@ impl Lens<Transform> for TransformRotateXLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateYLens {
@@ -207,7 +207,7 @@ impl Lens<Transform> for TransformRotateYLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateZLens {
@@ -237,7 +237,7 @@ impl Lens<Transform> for TransformRotateZLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateAdditiveXLens {
@@ -270,7 +270,7 @@ impl Lens<Transform> for TransformRotateAdditiveXLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateAdditiveYLens {
@@ -303,7 +303,7 @@ impl Lens<Transform> for TransformRotateAdditiveYLens {
 /// See the [top-level `lens` module documentation] for a comparison of rotation
 /// lenses.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateAdditiveZLens {
@@ -337,7 +337,7 @@ impl Lens<Transform> for TransformRotateAdditiveZLens {
 ///
 /// This method panics if the `axis` vector is not normalized.
 ///
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 /// [top-level `lens` module documentation]: crate::lens
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformRotateAxisLens {
@@ -358,8 +358,8 @@ impl Lens<Transform> for TransformRotateAxisLens {
 
 /// A lens to manipulate the [`scale`] field of a [`Transform`] component.
 ///
-/// [`scale`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html#structfield.scale
-/// [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+/// [`scale`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html#structfield.scale
+/// [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TransformScaleLens {
     /// Start value of the scale.
@@ -376,8 +376,8 @@ impl Lens<Transform> for TransformScaleLens {
 
 /// A lens to manipulate the [`position`] field of a UI [`Node`] component.
 ///
-/// [`position`]: https://docs.rs/bevy/0.18/bevy/ui/struct.Node.html
-/// [`Node`]: https://docs.rs/bevy/0.18/bevy/ui/struct.Node.html
+/// [`position`]: https://docs.rs/bevy/0.19/bevy/ui/struct.Node.html
+/// [`Node`]: https://docs.rs/bevy/0.19/bevy/ui/struct.Node.html
 #[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiPositionLens {
@@ -414,8 +414,8 @@ impl Lens<Node> for UiPositionLens {
 
 /// A lens to manipulate the [`scale`] field of a [`UiTransform`] component.
 ///
-/// [`scale`]: https://docs.rs/bevy/0.18/bevy/ui/ui_transform/struct.UiTransform.html#structfield.scale
-/// [`UiTransform`]: https://docs.rs/bevy/0.18/bevy/ui/ui_transform/struct.UiTransform.html
+/// [`scale`]: https://docs.rs/bevy/0.19/bevy/ui/ui_transform/struct.UiTransform.html#structfield.scale
+/// [`UiTransform`]: https://docs.rs/bevy/0.19/bevy/ui/ui_transform/struct.UiTransform.html
 #[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiTransformScaleLens {
@@ -434,8 +434,8 @@ impl Lens<UiTransform> for UiTransformScaleLens {
 
 /// A lens to manipulate the [`rotation`] field of a [`UiTransform`] component.
 ///
-/// [`rotation`]: https://docs.rs/bevy/0.18/bevy/ui/ui_transform/struct.UiTransform.html#structfield.rotation
-/// [`UiTransform`]: https://docs.rs/bevy/0.18/bevy/ui/ui_transform/struct.UiTransform.html
+/// [`rotation`]: https://docs.rs/bevy/0.19/bevy/ui/ui_transform/struct.UiTransform.html#structfield.rotation
+/// [`UiTransform`]: https://docs.rs/bevy/0.19/bevy/ui/ui_transform/struct.UiTransform.html
 #[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiTransformRotationLens {
@@ -455,8 +455,8 @@ impl Lens<UiTransform> for UiTransformRotationLens {
 /// A lens to manipulate the [`translation`] field of a [`UiTransform`]
 /// component.
 ///
-/// [`translation`]: https://docs.rs/bevy/0.18/bevy/ui/ui_transform/struct.UiTransform.html#structfield.translation
-/// [`UiTransform`]: https://docs.rs/bevy/0.18/bevy/ui/ui_transform/struct.UiTransform.html
+/// [`translation`]: https://docs.rs/bevy/0.19/bevy/ui/ui_transform/struct.UiTransform.html#structfield.translation
+/// [`UiTransform`]: https://docs.rs/bevy/0.19/bevy/ui/ui_transform/struct.UiTransform.html
 #[cfg(feature = "bevy_ui")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct UiTransformTranslationPxLens {
@@ -493,8 +493,8 @@ impl Lens<BackgroundColor> for UiBackgroundColorLens {
 
 /// A lens to manipulate the [`color`] field of a [`ColorMaterial`] asset.
 ///
-/// [`color`]: https://docs.rs/bevy/0.18/bevy/sprite/struct.ColorMaterial.html#structfield.color
-/// [`ColorMaterial`]: https://docs.rs/bevy/0.18/bevy/sprite/struct.ColorMaterial.html
+/// [`color`]: https://docs.rs/bevy/0.19.0/bevy/sprite_render/struct.ColorMaterial.html#structfield.color
+/// [`ColorMaterial`]: https://docs.rs/bevy/0.19.0/bevy/sprite_render/struct.ColorMaterial.html
 #[cfg(feature = "bevy_sprite")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ColorMaterialColorLens {
@@ -516,8 +516,8 @@ impl Lens<ColorMaterial> for ColorMaterialColorLens {
 
 /// A lens to manipulate the [`color`] field of a [`Sprite`] asset.
 ///
-/// [`color`]: https://docs.rs/bevy/0.18/bevy/sprite/struct.Sprite.html#structfield.color
-/// [`Sprite`]: https://docs.rs/bevy/0.18/bevy/sprite/struct.Sprite.html
+/// [`color`]: https://docs.rs/bevy/0.19/bevy/sprite/struct.Sprite.html#structfield.color
+/// [`Sprite`]: https://docs.rs/bevy/0.19/bevy/sprite/struct.Sprite.html
 #[cfg(feature = "bevy_sprite")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct SpriteColorLens {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,10 +283,10 @@
 //! shine for simpler animations while `bevy_animation` while offer a more
 //! extensive support for larger, more complex ones.
 //!
-//! [`Transform::translation`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html#structfield.translation
-//! [`Entity`]: https://docs.rs/bevy/0.18/bevy/ecs/entity/struct.Entity.html
-//! [`ColorMaterial`]: https://docs.rs/bevy/0.18/bevy/sprite/struct.ColorMaterial.html
-//! [`Transform`]: https://docs.rs/bevy/0.18/bevy/transform/components/struct.Transform.html
+//! [`Transform::translation`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html#structfield.translation
+//! [`Entity`]: https://docs.rs/bevy/0.19/bevy/ecs/entity/struct.Entity.html
+//! [`ColorMaterial`]: https://docs.rs/bevy/0.19.0/bevy/sprite_render/struct.ColorMaterial.html
+//! [`Transform`]: https://docs.rs/bevy/0.19/bevy/transform/components/struct.Transform.html
 //! [`TransformPositionLens`]: crate::lens::TransformPositionLens
 //! [`move_to()`]: crate::EntityCommandsTweeningExtensions::move_to
 


### PR DESCRIPTION
Here are the other updates that I had made for the PR. Including doc updates to some moved links etc.

I also think that when specifying font size in the examples, you should now declare the kind of sizing you're using...ie, px em etc since it is available. Not just use .into() for the default because the default could change.

Thanks for the great plugin!